### PR TITLE
unified/typed API for "clear" and "compressed" arrays

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,15 +1,19 @@
+LD = $(CC)
+LDFLAGS += -lmsgpackc
+EXE_EXT ?= .exe
+TEST_PROGRAMS = $(addsuffix $(EXE_EXT), multi demo traverse)
+
+all: $(TEST_PROGRAMS)
 
 clean:
-	rm *.o a.run
+	$(RM) *.o $(TEST_PROGRAMS)
 
-test: a.run
-	./a.run data/1MSH.mmtf
+test: run.demo
 
-mmtf_parser.o: mmtf_parser.c
-	gcc -c mmtf_parser.c
+run.%: %$(EXE_EXT)
+	./$< data/1MSH.mmtf
 
-demo.o: demo.c
-	gcc -c demo.c
+%$(EXE_EXT): mmtf_parser.o %.o
+	$(LD) -o $@ $^ $(LDFLAGS)
 
-a.run: mmtf_parser.o demo.o
-	gcc -o a.run mmtf_parser.o demo.o -lmsgpackc
+.PHONY: test

--- a/src/demo.c
+++ b/src/demo.c
@@ -21,5 +21,6 @@ int main(int argc, char** argv)
 	MMTF_container* example = MMTF_parser_MMTF_container_new();
 	MMTF_parser_MMTF_container_from_file(argv[1], example);
 	MMTF_parser_MMTF_container_destroy( example );
+	return 0;
 }
 

--- a/src/install-deps.sh
+++ b/src/install-deps.sh
@@ -2,6 +2,6 @@ export CXXFLAGS="-w -Wno-error -Wno-unknown-pragmas ${CXXFLAGS}";
 export CFLAGS="-w -Wno-error -Wno-error=format-security ${CFLAGS}";
 git clone https://github.com/msgpack/msgpack-c
 cd msgpack-c
-cmake .
+cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .
 make
 sudo make install

--- a/src/mmtf_parser.c
+++ b/src/mmtf_parser.c
@@ -25,18 +25,15 @@
 #define TYPEALIAS_char      char
 #define TYPEALIAS_int8      int8_t
 #define TYPEALIAS_int32     int32_t
-#define TYPEALIAS_lu        size_t
 #define TYPEALIAS_float     float
 #define TYPEALIAS_string    char*
 #define TYPEALIAS_int       int
 
 enum {
-    MMTF_TYPE_ANY = 0,
     MMTF_TYPE_char,
     MMTF_TYPE_int8 = MMTF_TYPE_char,
     MMTF_TYPE_int16,
     MMTF_TYPE_int32,
-    MMTF_TYPE_lu,
     MMTF_TYPE_float,
     MMTF_TYPE_string
 };
@@ -823,7 +820,7 @@ void* MMTF_parser_fetch_typed_array( const msgpack_object* object, uint64_t* len
             object->via.bin.size - 12, &out_length, strategy, parameter,
             &typecheck);
 
-    if (typecode != MMTF_TYPE_ANY && typecode != typecheck) {
+    if (typecode != typecheck) {
         fprintf(stderr, "Error in %s: typecode mismatch %d %d\n",
                 __FUNCTION__, typecode, typecheck);
         return NULL;
@@ -844,7 +841,6 @@ void* MMTF_parser_fetch_typed_array( const msgpack_object* object, uint64_t* len
 CODEGEN_MMTF_parser_fetch_array(char,   result[i] = iter->via.u64);
 CODEGEN_MMTF_parser_fetch_array(int8,   result[i] = iter->via.u64);
 CODEGEN_MMTF_parser_fetch_array(int32,  result[i] = iter->via.u64);
-CODEGEN_MMTF_parser_fetch_array(lu,     result[i] = iter->via.u64);
 CODEGEN_MMTF_parser_fetch_array(float,  result[i] = iter->via.f64);
 CODEGEN_MMTF_parser_fetch_array(string, MMTF_parser_put_string(iter, result + i));
 
@@ -857,7 +853,7 @@ void MMTF_parser_put_entity( const msgpack_object* object, MMTF_Entity* entity )
     MAP_ITERATE_BEGIN(object);
     FETCH_AND_ASSIGN(entity, string, description);
     FETCH_AND_ASSIGN(entity, string, type);
-    FETCH_AND_ASSIGN_DUMMYCOUNT(entity, lu_array, chainIndexList);
+    FETCH_AND_ASSIGN_DUMMYCOUNT(entity, int32_array, chainIndexList);
     FETCH_AND_ASSIGN(entity, string, sequence);
     MAP_ITERATE_END();
 }
@@ -887,7 +883,7 @@ void MMTF_parser_put_bioAssembly( const msgpack_object* object, MMTF_BioAssembly
 static
 void MMTF_parser_put_transform( const msgpack_object* object, MMTF_Transform* transform ) {
     MAP_ITERATE_BEGIN(object);
-    FETCH_AND_ASSIGN_DUMMYCOUNT(transform, lu_array, chainIndexList);
+    FETCH_AND_ASSIGN_DUMMYCOUNT(transform, int32_array, chainIndexList);
     FETCH_AND_ASSIGN_ARRAY(transform, float, matrix);
     MAP_ITERATE_END();
 }

--- a/src/mmtf_parser.c
+++ b/src/mmtf_parser.c
@@ -81,8 +81,8 @@ enum {
     msgpack_object_kv* current_key_value = object->via.map.ptr; \
     msgpack_object_kv* last_key_value = current_key_value + object->via.map.size; \
     for (; current_key_value != last_key_value; ++current_key_value ) { \
-        msgpack_object* key = &(current_key_value->key); \
-        msgpack_object* value = &(current_key_value->val); \
+        const msgpack_object* key = &(current_key_value->key); \
+        const msgpack_object* value = &(current_key_value->val); \
         if (key->type != MSGPACK_OBJECT_STR) \
                 continue;
 
@@ -181,9 +181,9 @@ enum {
             fprintf(stderr, "Error in %s: the entry encoded in the MMTF is not an array.\n", __FUNCTION__); \
             return NULL; \
         } \
-        msgpack_object* iter = object->via.array.ptr; \
+        const msgpack_object* iter = object->via.array.ptr; \
         (*length) = (uint64_t) object->via.array.size; \
-        msgpack_object* iter_end = iter + (*length); \
+        const msgpack_object* iter_end = iter + (*length); \
         type_ * result = MALLOC_ARRAY(type_, *length); \
         IF_NULL_ALLOCERROR_RETURN_NULL(result); \
         int i = 0; \
@@ -194,7 +194,8 @@ enum {
     }
 
 #define CODEGEN_MMTF_parser_fetch_array(type_, RESULT_I_ASSIGN) \
-    static TYPEALIAS_ ## type_ * MMTF_parser_fetch_ ## type_ ## _array(msgpack_object* object, uint64_t* length) { \
+    static TYPEALIAS_ ## type_ * MMTF_parser_fetch_ ## type_ ## _array( \
+            const msgpack_object* object, uint64_t* length) { \
         if (object->type == MSGPACK_OBJECT_BIN) { \
             return (TYPEALIAS_ ## type_*) \
             MMTF_parser_fetch_typed_array(object, length, MMTF_TYPE_ ## type_); \
@@ -203,7 +204,8 @@ enum {
     }
 
 #define CODEGEN_MMTF_parser_fetch_List(type_, suffix) \
-    type_ * MMTF_parser_fetch_ ## suffix ## List(msgpack_object* object, uint64_t* length) { \
+    type_ * MMTF_parser_fetch_ ## suffix ## List( \
+            const msgpack_object* object, uint64_t* length) { \
         CODEGEN_BODY_fetch_OBJECT_ARRAY(type_, { \
             MMTF_parser_put_ ## suffix(iter, result + i); \
         }) \
@@ -448,7 +450,7 @@ char** MMTF_parser_strings_from_bytes( const char* input, uint32_t input_length,
 
 //*** Array decoders
 // Run-length decode
-int32_t* MMTF_parser_run_length_decode( int32_t* input, uint32_t input_length, uint32_t* output_length ) {
+int32_t* MMTF_parser_run_length_decode(const int32_t* input, uint32_t input_length, uint32_t* output_length ) {
 	(*output_length) = 0;
 
 	IF_NOT_MULTIPLE_ERROR_RETURN(input_length, 2, NULL);
@@ -480,7 +482,7 @@ int32_t* MMTF_parser_run_length_decode( int32_t* input, uint32_t input_length, u
 }
 
 // Delta decode
-int32_t* MMTF_parser_delta_decode( int32_t* input, uint32_t input_length, uint32_t* output_length ) {
+int32_t* MMTF_parser_delta_decode(const int32_t* input, uint32_t input_length, uint32_t* output_length ) {
 	(*output_length) = input_length;
 	int32_t* output = MALLOC_ARRAY(int32_t, (*output_length)); // The output needs to be freed by the calling process
     IF_NULL_ALLOCERROR_RETURN_NULL(output);
@@ -495,7 +497,7 @@ int32_t* MMTF_parser_delta_decode( int32_t* input, uint32_t input_length, uint32
 }
 
 // Recursive indexing decode
-int32_t* MMTF_parser_recursive_indexing_decode_from_16( int16_t* input, uint32_t input_length, uint32_t* output_length ) {
+int32_t* MMTF_parser_recursive_indexing_decode_from_16(const int16_t* input, uint32_t input_length, uint32_t* output_length ) {
 	(*output_length) = 0;
 	uint32_t i;
 	for( i = 0; i < input_length; ++i ) {
@@ -523,7 +525,7 @@ int32_t* MMTF_parser_recursive_indexing_decode_from_16( int16_t* input, uint32_t
 	return output;
 }
 
-int32_t* MMTF_parser_recursive_indexing_decode_from_8( int8_t* input, uint32_t input_length, uint32_t* output_length ) {
+int32_t* MMTF_parser_recursive_indexing_decode_from_8(const int8_t* input, uint32_t input_length, uint32_t* output_length ) {
 	(*output_length) = 0;
 	uint32_t i;
 	for( i = 0; i < input_length; ++i ) {
@@ -551,7 +553,7 @@ int32_t* MMTF_parser_recursive_indexing_decode_from_8( int8_t* input, uint32_t i
 }
 
 // Integer decoding
-float* MMTF_parser_integer_decode_from_16( int16_t* input, uint32_t input_length, int32_t parameter, uint32_t* output_length ) {
+float* MMTF_parser_integer_decode_from_16(const int16_t* input, uint32_t input_length, int32_t parameter, uint32_t* output_length ) {
 	(*output_length) = input_length;
 	float* output = (float*) MALLOC_ARRAY(float, (*output_length) );
     IF_NULL_ALLOCERROR_RETURN_NULL(output);
@@ -565,7 +567,7 @@ float* MMTF_parser_integer_decode_from_16( int16_t* input, uint32_t input_length
 	return output;
 }
 
-float* MMTF_parser_integer_decode_from_32( int32_t* input, uint32_t input_length, int32_t parameter, uint32_t* output_length ) {
+float* MMTF_parser_integer_decode_from_32(const int32_t* input, uint32_t input_length, int32_t parameter, uint32_t* output_length ) {
 	(*output_length) = input_length;
 	float* output = (float*) MALLOC_ARRAY(float, (*output_length) );
     IF_NULL_ALLOCERROR_RETURN_NULL(output);
@@ -742,7 +744,7 @@ void* MMTF_parser_decode_apply_strategy( const char* input,
  * Copy string from 'object' to 'out'
  */
 static
-void MMTF_parser_put_string(msgpack_object* object, char** out) {
+void MMTF_parser_put_string(const msgpack_object* object, char** out) {
     size_t string_size = object->via.str.size;
     char * result = (*out) = MALLOC_ARRAY(char, (string_size + 1));
     IF_NULL_ALLOCERROR_RETURN(result,);
@@ -751,7 +753,7 @@ void MMTF_parser_put_string(msgpack_object* object, char** out) {
 }
 
 //*** Unpacking from MsgPack and applying strategy
-char* MMTF_parser_fetch_string( msgpack_object* object ) {
+char* MMTF_parser_fetch_string( const msgpack_object* object ) {
 	if( object->type != MSGPACK_OBJECT_STR ) {
 		fprintf( stderr, "Error in %s: the entry encoded in the MMTF is not a string.\n", __FUNCTION__ );
 		return NULL;
@@ -762,7 +764,7 @@ char* MMTF_parser_fetch_string( msgpack_object* object ) {
 	return result;
 }
 
-char MMTF_parser_fetch_char( msgpack_object* object ) {
+char MMTF_parser_fetch_char( const msgpack_object* object ) {
 	if( object->type != MSGPACK_OBJECT_STR) {
 		fprintf( stderr, "Error in %s: the entry encoded in the MMTF is not a string.\n", __FUNCTION__ );
 		return '\0';
@@ -771,7 +773,7 @@ char MMTF_parser_fetch_char( msgpack_object* object ) {
 	return *(object->via.str.ptr);
 }
 
-int64_t MMTF_parser_fetch_int( msgpack_object* object ) {
+int64_t MMTF_parser_fetch_int( const msgpack_object* object ) {
 	int64_t result;
 
     if(object->type == MSGPACK_OBJECT_POSITIVE_INTEGER) {
@@ -788,7 +790,7 @@ int64_t MMTF_parser_fetch_int( msgpack_object* object ) {
 	return result;
 }
 
-float MMTF_parser_fetch_float( msgpack_object* object ) {
+float MMTF_parser_fetch_float( const msgpack_object* object ) {
 	if( object->type != MSGPACK_OBJECT_FLOAT ) {
 		fprintf( stderr, "Error in %s: the entry encoded in the MMTF is not a float.\n", __FUNCTION__ );
 		return NAN;
@@ -801,7 +803,7 @@ float MMTF_parser_fetch_float( msgpack_object* object ) {
  * Fetch a compressed typed array
  */
 static
-void* MMTF_parser_fetch_typed_array( msgpack_object* object, uint64_t* length, int typecode) {
+void* MMTF_parser_fetch_typed_array( const msgpack_object* object, uint64_t* length, int typecode) {
 	if( object->type != MSGPACK_OBJECT_BIN ) {
 		fprintf( stderr, "Error in %s: the entry encoded in the MMTF is not binary data.\n", __FUNCTION__ );
 		return NULL;
@@ -851,7 +853,7 @@ bool MMTF_parser_compare_msgpack_string_char_array( const msgpack_object_str* m_
 }
 
 static
-void MMTF_parser_put_entity( msgpack_object* object, MMTF_Entity* entity ) {
+void MMTF_parser_put_entity( const msgpack_object* object, MMTF_Entity* entity ) {
     MAP_ITERATE_BEGIN(object);
     FETCH_AND_ASSIGN(entity, string, description);
     FETCH_AND_ASSIGN(entity, string, type);
@@ -861,7 +863,7 @@ void MMTF_parser_put_entity( msgpack_object* object, MMTF_Entity* entity ) {
 }
 
 static
-void MMTF_parser_put_group( msgpack_object* object, MMTF_GroupType* group_type ) {
+void MMTF_parser_put_group( const msgpack_object* object, MMTF_GroupType* group_type ) {
     MAP_ITERATE_BEGIN(object);
     FETCH_AND_ASSIGN_DUMMYCOUNT(group_type, int32_array, formalChargeList);
     FETCH_AND_ASSIGN_WITHCOUNT(group_type, string_array, atomNameList);
@@ -875,7 +877,7 @@ void MMTF_parser_put_group( msgpack_object* object, MMTF_GroupType* group_type )
 }
 
 static
-void MMTF_parser_put_bioAssembly( msgpack_object* object, MMTF_BioAssembly* bio_assembly ) {
+void MMTF_parser_put_bioAssembly( const msgpack_object* object, MMTF_BioAssembly* bio_assembly ) {
     MAP_ITERATE_BEGIN(object);
     FETCH_AND_ASSIGN(bio_assembly, string, name);
     FETCH_AND_ASSIGN_WITHCOUNT(bio_assembly, transformList, transformList);
@@ -883,7 +885,7 @@ void MMTF_parser_put_bioAssembly( msgpack_object* object, MMTF_BioAssembly* bio_
 }
 
 static
-void MMTF_parser_put_transform( msgpack_object* object, MMTF_Transform* transform ) {
+void MMTF_parser_put_transform( const msgpack_object* object, MMTF_Transform* transform ) {
     MAP_ITERATE_BEGIN(object);
     FETCH_AND_ASSIGN_DUMMYCOUNT(transform, lu_array, chainIndexList);
     FETCH_AND_ASSIGN_ARRAY(transform, float, matrix);
@@ -895,7 +897,7 @@ CODEGEN_MMTF_parser_fetch_List(MMTF_GroupType, group);
 CODEGEN_MMTF_parser_fetch_List(MMTF_BioAssembly, bioAssembly);
 CODEGEN_MMTF_parser_fetch_List(MMTF_Transform, transform);
 
-void MMTF_parser_msgpack_object_to_MMTF_container(msgpack_object* object, MMTF_container* thing) {
+void MMTF_parser_msgpack_object_to_MMTF_container(const msgpack_object* object, MMTF_container* thing) {
     MAP_ITERATE_BEGIN(object);
     FETCH_AND_ASSIGN(thing, string, mmtfVersion);
     FETCH_AND_ASSIGN(thing, string, mmtfProducer);

--- a/src/mmtf_parser.h
+++ b/src/mmtf_parser.h
@@ -30,30 +30,21 @@
 #include <stdint.h>
 #include <stdio.h>
 
-//*** MMTF type codes
-enum {
-    MMTF_TYPE_ANY = 0,
-    MMTF_TYPE_INT,
-    MMTF_TYPE_INT8,
-    MMTF_TYPE_INT16,
-    MMTF_TYPE_INT32,
-    MMTF_TYPE_LU,
-    MMTF_TYPE_FLOAT,
-    MMTF_TYPE_STRING,
-    MMTF_TYPE_STRINGS
-};
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 //*** The MMTF structure
 typedef struct {
-    int *				formalChargeList;    // List of formal charges as Integers
+    int32_t *				formalChargeList;    // List of formal charges as Integers
 	uint64_t			atomNameListCount;
     char **				atomNameList;        // List of atom names, 0 to 5 character Strings
 	uint64_t			elementListCount;
     char **				elementList;         // List of elements, 0 to 3 character Strings
 	uint64_t			bondAtomListCount;
-    int *				bondAtomList;        // List of bonded atom indices, Integers
+    int32_t *				bondAtomList;        // List of bonded atom indices, Integers
 	uint64_t			bondOrderListCount;
-    char *				bondOrderList;       // List of bond orders as Integers between 1 and 4
+    int8_t *				bondOrderList;       // List of bond orders as Integers between 1 and 4
     char *				groupName;           // The name of the group, 0 to 5 characters
     char				singleLetterCode;    // The single letter code, 1 character
     char *				chemCompType;         // The chemical component type
@@ -128,7 +119,7 @@ typedef struct {
     float *				yCoordList;
     float *				zCoordList;
     float *				bFactorList;
-    signed int *		atomIdList;
+    int32_t *		atomIdList;
     char *				altLocList;
     float *				occupancyList;
     int32_t *			groupIdList;
@@ -143,7 +134,6 @@ typedef struct {
     int32_t *			groupsPerChain;
     int32_t *			chainsPerModel;
 } MMTF_container;
-
 
 //*** Create a struct
 MMTF_container* MMTF_parser_MMTF_container_new( void );
@@ -233,17 +223,8 @@ float* MMTF_parser_integer_decode_from_32( int32_t*, uint32_t, int32_t, uint32_t
 
 //*** Unpacking from MsgPack and applying strategy
 char* MMTF_parser_fetch_string( msgpack_object* );
-uint64_t MMTF_parser_fetch_int( msgpack_object* );
+int64_t MMTF_parser_fetch_int( msgpack_object* );
 float MMTF_parser_fetch_float( msgpack_object* );
-void* MMTF_parser_fetch_array( msgpack_object*, uint64_t* );
-void* MMTF_parser_fetch_array_generic( msgpack_object* object, uint64_t* length, int typenum);
-
-size_t* MMTF_parser_fetch_clear_lu_array( msgpack_object*, uint64_t* );
-int* MMTF_parser_fetch_clear_int_array( msgpack_object*, uint64_t* );
-int32_t* MMTF_parser_fetch_clear_int32_array( msgpack_object*, uint64_t* );
-char* MMTF_parser_fetch_clear_int8_array( msgpack_object*, uint64_t* );
-float* MMTF_parser_fetch_clear_float_array( msgpack_object*, uint64_t* );
-char** MMTF_parser_fetch_clear_string_array( msgpack_object*, uint64_t* );
 
 bool MMTF_parser_compare_msgpack_string_char_array( const msgpack_object_str*, const char* );
 
@@ -257,10 +238,13 @@ MMTF_Transform* MMTF_parser_fetch_transformList( msgpack_object*, uint64_t* );
 
 //*** MMTF and MsgPack
 void MMTF_parser_msgpack_object_to_MMTF_container( msgpack_object*, MMTF_container* );
-void MMTF_parser_parse_msgpack( char*, int, MMTF_container* );
+void MMTF_parser_parse_msgpack(const char*, int, MMTF_container* );
 
 
 //*** Decode a MMTF container from a file
-void MMTF_parser_MMTF_container_from_file( char*, MMTF_container* );
+void MMTF_parser_MMTF_container_from_file(const char*, MMTF_container* );
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/src/mmtf_parser.h
+++ b/src/mmtf_parser.h
@@ -51,14 +51,14 @@ typedef struct {
 } MMTF_GroupType;
 
 typedef struct {
-    size_t *			chainIndexList;   // Indices of fields in chainIdList and chainNameList fields
+    int32_t *			chainIndexList;   // Indices of fields in chainIdList and chainNameList fields
     char *				description;      // Description of the entity
     char *				type;             // Name of the entity type
     char *				sequence;          // Sequence of the full construct in one-letter-code
 } MMTF_Entity;
 
 typedef struct {
-	size_t*				chainIndexList;
+	int32_t *				chainIndexList;
 	float				matrix[16];
 } MMTF_Transform;
 

--- a/src/mmtf_parser.h
+++ b/src/mmtf_parser.h
@@ -208,36 +208,36 @@ char** MMTF_parser_strings_from_bytes( const char*, uint32_t, uint32_t, uint32_t
 
 //*** Array decoders
 // Run-length decode
-int32_t* MMTF_parser_run_length_decode( int32_t*, uint32_t, uint32_t*);
+int32_t* MMTF_parser_run_length_decode(const int32_t*, uint32_t, uint32_t*);
 
 // Delta decode
-int32_t* MMTF_parser_delta_decode( int32_t*, uint32_t, uint32_t* );
+int32_t* MMTF_parser_delta_decode(const int32_t*, uint32_t, uint32_t* );
 
 // Recursive indexing decode
-int32_t* MMTF_parser_recursive_indexing_decode_from_16( int16_t*, uint32_t, uint32_t*);
-int32_t* MMTF_parser_recursive_indexing_decode_from_8( int8_t*, uint32_t, uint32_t* );
+int32_t* MMTF_parser_recursive_indexing_decode_from_16(const int16_t*, uint32_t, uint32_t*);
+int32_t* MMTF_parser_recursive_indexing_decode_from_8(const int8_t*, uint32_t, uint32_t* );
 
 // Integer decoding
-float* MMTF_parser_integer_decode_from_16( int16_t*, uint32_t, int32_t, uint32_t* );
-float* MMTF_parser_integer_decode_from_32( int32_t*, uint32_t, int32_t, uint32_t* );
+float* MMTF_parser_integer_decode_from_16(const int16_t*, uint32_t, int32_t, uint32_t* );
+float* MMTF_parser_integer_decode_from_32(const int32_t*, uint32_t, int32_t, uint32_t* );
 
 //*** Unpacking from MsgPack and applying strategy
-char* MMTF_parser_fetch_string( msgpack_object* );
-int64_t MMTF_parser_fetch_int( msgpack_object* );
-float MMTF_parser_fetch_float( msgpack_object* );
+char* MMTF_parser_fetch_string( const msgpack_object* );
+int64_t MMTF_parser_fetch_int( const msgpack_object* );
+float MMTF_parser_fetch_float( const msgpack_object* );
 
 bool MMTF_parser_compare_msgpack_string_char_array( const msgpack_object_str*, const char* );
 
-MMTF_Entity* MMTF_parser_fetch_entityList( msgpack_object*, uint64_t* );
+MMTF_Entity* MMTF_parser_fetch_entityList( const msgpack_object*, uint64_t* );
 
-MMTF_GroupType* MMTF_parser_fetch_groupTypeList( msgpack_object*, uint64_t* );
+MMTF_GroupType* MMTF_parser_fetch_groupTypeList( const msgpack_object*, uint64_t* );
 
-MMTF_BioAssembly* MMTF_parser_fetch_bioAssemblyList( msgpack_object*, uint64_t* );
-MMTF_Transform* MMTF_parser_fetch_transformList( msgpack_object*, uint64_t* );
+MMTF_BioAssembly* MMTF_parser_fetch_bioAssemblyList( const msgpack_object*, uint64_t* );
+MMTF_Transform* MMTF_parser_fetch_transformList( const msgpack_object*, uint64_t* );
 
 
 //*** MMTF and MsgPack
-void MMTF_parser_msgpack_object_to_MMTF_container( msgpack_object*, MMTF_container* );
+void MMTF_parser_msgpack_object_to_MMTF_container( const msgpack_object*, MMTF_container* );
 void MMTF_parser_parse_msgpack(const char*, int, MMTF_container* );
 
 

--- a/src/multi.c
+++ b/src/multi.c
@@ -17,7 +17,7 @@
 #include "demo.h"
 
 
-void read_file(char* input_path){
+void read_file(const char* input_path){
         MMTF_container* example = MMTF_parser_MMTF_container_new();
         MMTF_parser_MMTF_container_from_file(input_path, example);
         MMTF_parser_MMTF_container_destroy( example );

--- a/src/traverse.c
+++ b/src/traverse.c
@@ -16,6 +16,11 @@
 
 #include "demo.h"
 
+static
+char safechar(char c) {
+  return (c < ' ') ? '.' : c;
+}
+
 int main(int argc, char** argv)
 {
 	MMTF_container* example = MMTF_parser_MMTF_container_new();
@@ -33,7 +38,7 @@ int main(int argc, char** argv)
     int i;
 for(i=0;  i<example->numModels; i++){
     int modelChainCount = example->chainsPerModel[i];
-    printf("modelIndex: %d",modelIndex);
+    printf("modelIndex: %d\n",modelIndex);
 //    # traverse chains
 	int j;
     for(j=0; j< modelChainCount; j++){
@@ -46,8 +51,8 @@ for(i=0;  i<example->numModels; i++){
         for(k=0; k<chainGroupCount;k++){
             printf("groupIndex: %d\n",groupIndex);
             printf("groupId: %d\n", example->groupIdList[ groupIndex ]);
-            printf("insCodeList: %c\n",example->insCodeList[ groupIndex ]);
-            printf("secStruc: %c\n",example->secStructList[ groupIndex ]);
+            printf("insCodeList: %c\n", safechar(example->insCodeList[ groupIndex ]));
+            printf("secStruc: %d\n",example->secStructList[ groupIndex ]);
             printf("seqIndex: %i\n",example->sequenceIndexList[ groupIndex ]);
             printf("groupType: %d\n",example->groupTypeList[ groupIndex ]);
             MMTF_GroupType group = example->groupList[ example->groupTypeList[ groupIndex ] ];
@@ -71,7 +76,7 @@ for(i=0;  i<example->numModels; i++){
                 printf("z coord: %f\n", example->zCoordList[ atomIndex ]);
                 printf("b factor: %f\n", example->bFactorList[ atomIndex ]);
                 printf("atom id: %d\n", example->atomIdList[ atomIndex ]);
-                printf("altLocList: %c\n", example->altLocList[ atomIndex ]);
+                printf("altLocList: %c\n", safechar(example->altLocList[ atomIndex ]));
                 printf("occupancy: %f\n", example->occupancyList[ atomIndex ]);
                 printf("charge: %d\n", group.formalChargeList[ l ]);
                 printf("atom name: %s\n", group.atomNameList[ l ]);


### PR DESCRIPTION
- "MMTF_parser_fetch_*_array" handles clear and compressed arrays
- unpacking of compressed arrays now type safe
- big-endian: use ntohl and ntohs
- remove lu type, use int32 according to MMTF spec (chainIndexList)
