### PR TITLE
code formatting, comments and documentation, semantic versioning

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+---
+Language:        Cpp
+BasedOnStyle:    LLVM
+AlignAfterOpenBracket: false
+ColumnLimit:     0
+ContinuationIndentWidth: 8
+IndentWidth:     4
+PointerAlignment: Left
+Standard:        Cpp03
+...
+

--- a/codeformat.sh
+++ b/codeformat.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+CLANG_FORMAT="clang-format"
+
+GSED=$(which gsed 2>/dev/null || echo sed)
+
+if ! $GSED --version >/dev/null 2>/dev/null; then
+    echo "error: GNU sed required"
+    exit 2
+fi
+
+SOURCEFILES="src/mmtf_parser*.h src/mmtf_parser.c"
+
+# formatting based on .clang-format
+$CLANG_FORMAT -i $SOURCEFILES
+
+# don't align backslashes (line continuation)
+$GSED -i 's!  *\\$! \\!' $SOURCEFILES
+
+# break after "static"
+$GSED -i 's!^\(static\( inline\)\?\) !\1\n!' $SOURCEFILES

--- a/src/mmtf_parser.c
+++ b/src/mmtf_parser.c
@@ -42,6 +42,7 @@
 #include <arpa/inet.h>
 #endif
 
+// clang-format off
 // typed array memory allocation
 #define MALLOC_ARRAY(type, size) (type*) malloc((size) * sizeof(type))
 
@@ -55,6 +56,7 @@
 #define TYPEALIAS_float     float
 #define TYPEALIAS_string    char*
 #define TYPEALIAS_int       int
+// clang-format on
 
 enum {
     MMTF_TYPE_char,
@@ -77,15 +79,15 @@ enum {
 
 #define IF_NULL_ALLOCERROR_RETURN(ptr, returnvalue) \
     if (!ptr) { \
-        fprintf(stderr, "Error in %s: couldn't allocate memory.\n", __FUNCTION__ ); \
+        fprintf(stderr, "Error in %s: couldn't allocate memory.\n", __FUNCTION__); \
         return returnvalue; \
     }
 
 #define IF_NOT_MULTIPLE_ERROR_RETURN(length, size, returnvalue) \
-	if((length) % (size) != 0) { \
-		fprintf(stderr, "Error in %s: length %u is not a multiple of %u.\n", __FUNCTION__, length, size ); \
-		return returnvalue; \
-	}
+    if ((length) % (size) != 0) { \
+        fprintf(stderr, "Error in %s: length %u is not a multiple of %u.\n", __FUNCTION__, length, size); \
+        return returnvalue; \
+    }
 
 #define IF_NULL_ALLOCERROR_RETURN_NULL(ptr) \
     IF_NULL_ALLOCERROR_RETURN(ptr, NULL)
@@ -101,11 +103,11 @@ enum {
     } \
     msgpack_object_kv* current_key_value = object->via.map.ptr; \
     msgpack_object_kv* last_key_value = current_key_value + object->via.map.size; \
-    for (; current_key_value != last_key_value; ++current_key_value ) { \
+    for (; current_key_value != last_key_value; ++current_key_value) { \
         const msgpack_object* key = &(current_key_value->key); \
         const msgpack_object* value = &(current_key_value->val); \
         if (key->type != MMTF_MSGPACK_TYPE(STR)) \
-                continue;
+            continue;
 
 #define MAP_ITERATE_END() }
 
@@ -115,30 +117,32 @@ enum {
 
 #define FETCH_AND_ASSIGN(this_, type, name) \
     if (MMTF_parser_compare_msgpack_string_char_array(&(key->via.str), #name)) { \
-        this_->name = MMTF_parser_fetch_ ## type(value); \
+        this_->name = MMTF_parser_fetch_##type(value); \
         continue; \
     }
 
 #define FETCH_AND_ASSIGN_DUMMYCOUNT(this_, type, name) \
     if (MMTF_parser_compare_msgpack_string_char_array(&(key->via.str), #name)) { \
         size_t _length; \
-        this_->name = MMTF_parser_fetch_ ## type(value, &_length); \
+        this_->name = MMTF_parser_fetch_##type(value, &_length); \
         continue; \
     }
 
 #define FETCH_AND_ASSIGN_WITHCOUNT(this_, type, name) \
     if (MMTF_parser_compare_msgpack_string_char_array(&(key->via.str), #name)) { \
-        this_->name = MMTF_parser_fetch_ ## type(value, &(this_->name ## Count)); \
+        this_->name = MMTF_parser_fetch_##type(value, &(this_->name##Count)); \
         continue; \
     }
 
 #define FETCH_AND_ASSIGN_ARRAY(this_, type, name) \
-    if (MMTF_parser_compare_msgpack_string_char_array( &(key->via.str), #name )) { \
+    if (MMTF_parser_compare_msgpack_string_char_array(&(key->via.str), #name)) { \
         size_t _length; \
-        type * array = MMTF_parser_fetch_ ## type ## _array(value, &_length); \
+        type* array = MMTF_parser_fetch_##type##_array(value, &_length); \
         if (array != NULL) { \
             int i; \
-            for(i = 0; i < _length; ++i) { this_->name[i] = array[i]; } \
+            for (i = 0; i < _length; ++i) { \
+                this_->name[i] = array[i]; \
+            } \
             free(array); \
         } \
     }
@@ -148,45 +152,47 @@ enum {
  */
 
 #define CODEGEN_MMTF_parser_TYPE_init(type) \
-    void type ## _init(type * result) { \
+    void type##_init(type* result) { \
         memset(result, 0, sizeof(type)); \
     }
 
 #define CODEGEN_MMTF_parser_TYPE_new(type) \
-    type * type ## _new(void) { \
-        type * result = (type*) malloc(sizeof(type)); \
+    type* type##_new(void) { \
+        type* result = (type*)malloc(sizeof(type)); \
         IF_NULL_ALLOCERROR_RETURN_NULL(result); \
-        type ## _init(result); \
+        type##_init(result); \
         return result; \
     }
 
 #define CODEGEN_MMTF_parser_TYPE_clear(type) \
-    void type ## _clear(type * result) { \
-        IF_NULL_PTRERROR_RETURN(result,); \
-        type ## _destroy(result); \
-        type ## _init(result); \
+    void type##_clear(type* result) { \
+        IF_NULL_PTRERROR_RETURN(result, ); \
+        type##_destroy(result); \
+        type##_init(result); \
     }
 
 #define CODEGEN_MMTF_parser_TYPE_free(type) \
-    void type ## _free(type * thing) { \
-        IF_NULL_PTRERROR_RETURN(thing,); \
-        type ## _destroy(thing); \
+    void type##_free(type* thing) { \
+        IF_NULL_PTRERROR_RETURN(thing, ); \
+        type##_destroy(thing); \
         free(thing); \
     }
 
+// clang-format off
 #define CODEGEN_MMTF_parser_TYPE(type) \
     CODEGEN_MMTF_parser_TYPE_init(type) \
     CODEGEN_MMTF_parser_TYPE_new(type) \
     CODEGEN_MMTF_parser_TYPE_clear(type) \
     CODEGEN_MMTF_parser_TYPE_free(type)
+// clang-format on
 
 #define generic_destroy(ptr) \
     free(*(ptr))
 
 #define FREE_LIST(type_, name) \
     if (name != NULL) { \
-        for (i = 0; i < name ## Count; ++i) { \
-            type_ ## _destroy(name + i); \
+        for (i = 0; i < name##Count; ++i) { \
+            type_##_destroy(name + i); \
         } \
         free(name); \
     }
@@ -204,36 +210,39 @@ enum {
         const msgpack_object* iter = object->via.array.ptr; \
         (*length) = object->via.array.size; \
         const msgpack_object* iter_end = iter + (*length); \
-        type_ * result = MALLOC_ARRAY(type_, *length); \
+        type_* result = MALLOC_ARRAY(type_, *length); \
         IF_NULL_ALLOCERROR_RETURN_NULL(result); \
         int i = 0; \
-        for (; iter != iter_end ; ++iter, ++i) { \
+        for (; iter != iter_end; ++iter, ++i) { \
             RESULT_I_ASSIGN; \
         } \
         return result; \
     }
 
+// clang-format off
 #define CODEGEN_MMTF_parser_fetch_array(type_, RESULT_I_ASSIGN) \
-    static TYPEALIAS_ ## type_ * MMTF_parser_fetch_ ## type_ ## _array( \
+    static TYPEALIAS_##type_* MMTF_parser_fetch_##type_##_array( \
             const msgpack_object* object, size_t* length) { \
         if (object->type == MMTF_MSGPACK_TYPE(BIN)) { \
-            return (TYPEALIAS_ ## type_*) \
-            MMTF_parser_fetch_typed_array(object, length, MMTF_TYPE_ ## type_); \
+            return (TYPEALIAS_##type_*) \
+            MMTF_parser_fetch_typed_array(object, length, MMTF_TYPE_##type_); \
         } \
-        CODEGEN_BODY_fetch_OBJECT_ARRAY(TYPEALIAS_ ## type_, RESULT_I_ASSIGN); \
+        CODEGEN_BODY_fetch_OBJECT_ARRAY(TYPEALIAS_##type_, RESULT_I_ASSIGN); \
     }
 
 #define CODEGEN_MMTF_parser_fetch_List(type_, suffix) \
-    type_ * MMTF_parser_fetch_ ## suffix ## List( \
+    type_* MMTF_parser_fetch_##suffix##List( \
             const msgpack_object* object, size_t* length) { \
         CODEGEN_BODY_fetch_OBJECT_ARRAY(type_, { \
-            MMTF_parser_put_ ## suffix(iter, result + i); \
+            MMTF_parser_put_##suffix(iter, result + i); \
         }) \
     }
+// clang-format on
 
 /*
  * Generate "initialize", "new", "empty" and "destroy" functions for MMTF struct types.
  */
+// clang-format off
 CODEGEN_MMTF_parser_TYPE(MMTF_container)
 CODEGEN_MMTF_parser_TYPE(MMTF_BioAssembly)
 CODEGEN_MMTF_parser_TYPE(MMTF_Transform)
@@ -242,8 +251,9 @@ CODEGEN_MMTF_parser_TYPE(MMTF_GroupType)
 
 //*** Destroy the innner of a struct
 void MMTF_container_destroy(MMTF_container* thing) {
+    // clang-format on
     size_t i;
-    IF_NULL_PTRERROR_RETURN(thing,);
+    IF_NULL_PTRERROR_RETURN(thing, );
 
     FREE_LIST(MMTF_BioAssembly, thing->bioAssemblyList);
     FREE_LIST(MMTF_Entity, thing->entityList);
@@ -252,74 +262,74 @@ void MMTF_container_destroy(MMTF_container* thing) {
     FREE_LIST(generic, thing->chainIdList);
     FREE_LIST(generic, thing->chainNameList);
 
-    free( thing->mmtfVersion );
-    free( thing->mmtfProducer );
-    free( thing->spaceGroup );
-    free( thing->structureId );
-    free( thing->title );
-    free( thing->depositionDate );
-    free( thing->releaseDate );
-    free( thing->bondAtomList );
-    free( thing->bondOrderList );
-    free( thing->xCoordList );
-    free( thing->yCoordList );
-    free( thing->zCoordList );
-    free( thing->bFactorList );
-    free( thing->atomIdList );
-    free( thing->altLocList );
-    free( thing->occupancyList );
-    free( thing->groupIdList );
-    free( thing->groupTypeList );
-    free( thing->secStructList );
-    free( thing->insCodeList );
-    free( thing->sequenceIndexList );
-    free( thing->groupsPerChain );
-    free( thing->chainsPerModel );
+    free(thing->mmtfVersion);
+    free(thing->mmtfProducer);
+    free(thing->spaceGroup);
+    free(thing->structureId);
+    free(thing->title);
+    free(thing->depositionDate);
+    free(thing->releaseDate);
+    free(thing->bondAtomList);
+    free(thing->bondOrderList);
+    free(thing->xCoordList);
+    free(thing->yCoordList);
+    free(thing->zCoordList);
+    free(thing->bFactorList);
+    free(thing->atomIdList);
+    free(thing->altLocList);
+    free(thing->occupancyList);
+    free(thing->groupIdList);
+    free(thing->groupTypeList);
+    free(thing->secStructList);
+    free(thing->insCodeList);
+    free(thing->sequenceIndexList);
+    free(thing->groupsPerChain);
+    free(thing->chainsPerModel);
 }
 void MMTF_BioAssembly_destroy(MMTF_BioAssembly* bio_assembly) {
     size_t i;
-    IF_NULL_PTRERROR_RETURN(bio_assembly,);
+    IF_NULL_PTRERROR_RETURN(bio_assembly, );
     FREE_LIST(MMTF_Transform, bio_assembly->transformList);
-    free( bio_assembly->name );
+    free(bio_assembly->name);
 }
 void MMTF_Transform_destroy(MMTF_Transform* transform) {
-    IF_NULL_PTRERROR_RETURN(transform,);
-    free( transform->chainIndexList );
+    IF_NULL_PTRERROR_RETURN(transform, );
+    free(transform->chainIndexList);
 }
 void MMTF_Entity_destroy(MMTF_Entity* entity) {
-    IF_NULL_PTRERROR_RETURN(entity,);
-    free( entity->chainIndexList );
-    free( entity->description );
-    free( entity->type );
-    free( entity->sequence );
+    IF_NULL_PTRERROR_RETURN(entity, );
+    free(entity->chainIndexList);
+    free(entity->description);
+    free(entity->type);
+    free(entity->sequence);
 }
 void MMTF_GroupType_destroy(MMTF_GroupType* group_type) {
     size_t i;
-    IF_NULL_PTRERROR_RETURN(group_type,);
+    IF_NULL_PTRERROR_RETURN(group_type, );
     FREE_LIST(generic, group_type->atomNameList);
     FREE_LIST(generic, group_type->elementList);
-    free( group_type->formalChargeList );
-    free( group_type->bondAtomList );
-    free( group_type->bondOrderList );
-    free( group_type->groupName );
-    free( group_type->chemCompType );
+    free(group_type->formalChargeList);
+    free(group_type->bondAtomList);
+    free(group_type->bondOrderList);
+    free(group_type->groupName);
+    free(group_type->chemCompType);
 }
 
 //*** Array converters
 // From bytes[] to float32[], int8[], int16[], int32[] and string
 
 static inline
-void assign_bigendian_4(void * dst, const char * src) {
+void assign_bigendian_4(void* dst, const char* src) {
     *((uint32_t*)dst) = ntohl(*((uint32_t*)src));
 }
 
 static inline
-void assign_bigendian_2(void * dst, const char * src) {
+void assign_bigendian_2(void* dst, const char* src) {
     *((uint16_t*)dst) = ntohs(*((uint16_t*)src));
 }
 
 static
-void array_copy_bigendian_4(void * dst, const char * src, size_t n) {
+void array_copy_bigendian_4(void* dst, const char* src, size_t n) {
     size_t i;
     for (i = 0; i < n; i += 4) {
         assign_bigendian_4(((char*)dst) + i, src + i);
@@ -327,373 +337,371 @@ void array_copy_bigendian_4(void * dst, const char * src, size_t n) {
 }
 
 static
-void array_copy_bigendian_2(void * dst, const char * src, size_t n) {
+void array_copy_bigendian_2(void* dst, const char* src, size_t n) {
     size_t i;
     for (i = 0; i < n; i += 2) {
         assign_bigendian_2(((char*)dst) + i, src + i);
     }
 }
 
-float* MMTF_parser_float_from_bytes( const char* input, uint32_t input_length, uint32_t* output_length ) {
-	IF_NOT_MULTIPLE_ERROR_RETURN(input_length, 4, NULL);
+float* MMTF_parser_float_from_bytes(const char* input, uint32_t input_length, uint32_t* output_length) {
+    IF_NOT_MULTIPLE_ERROR_RETURN(input_length, 4, NULL);
 
-	(*output_length) = input_length/4;
+    (*output_length) = input_length / 4;
 
-	float* output = MALLOC_ARRAY(float, *output_length);
+    float* output = MALLOC_ARRAY(float, *output_length);
     IF_NULL_ALLOCERROR_RETURN_NULL(output);
 
-	array_copy_bigendian_4(output, input, input_length);
+    array_copy_bigendian_4(output, input, input_length);
 
-	return output;
+    return output;
 }
 
-int8_t* MMTF_parser_int8_from_bytes( const char* input, uint32_t input_length, uint32_t* output_length ) {
-	(*output_length) = input_length;
+int8_t* MMTF_parser_int8_from_bytes(const char* input, uint32_t input_length, uint32_t* output_length) {
+    (*output_length) = input_length;
 
-	int8_t* output = MALLOC_ARRAY(int8_t, *output_length);
+    int8_t* output = MALLOC_ARRAY(int8_t, *output_length);
     IF_NULL_ALLOCERROR_RETURN_NULL(output);
 
-	memcpy(output, input, input_length);
+    memcpy(output, input, input_length);
 
-	return output;
+    return output;
 }
 
-int16_t* MMTF_parser_int16_from_bytes( const char* input, uint32_t input_length, uint32_t* output_length ) {
-	IF_NOT_MULTIPLE_ERROR_RETURN(input_length, 2, NULL);
+int16_t* MMTF_parser_int16_from_bytes(const char* input, uint32_t input_length, uint32_t* output_length) {
+    IF_NOT_MULTIPLE_ERROR_RETURN(input_length, 2, NULL);
 
-	(*output_length) = input_length/2;
+    (*output_length) = input_length / 2;
 
-	int16_t* output = MALLOC_ARRAY(int16_t, (*output_length) );
+    int16_t* output = MALLOC_ARRAY(int16_t, (*output_length));
     IF_NULL_ALLOCERROR_RETURN_NULL(output);
 
-	array_copy_bigendian_2(output, input, input_length);
+    array_copy_bigendian_2(output, input, input_length);
 
-	return output;
+    return output;
 }
 
-int32_t* MMTF_parser_int32_from_bytes( const char* input, const uint32_t input_length, uint32_t* output_length ) {
-	IF_NOT_MULTIPLE_ERROR_RETURN(input_length, 4, NULL);
+int32_t* MMTF_parser_int32_from_bytes(const char* input, const uint32_t input_length, uint32_t* output_length) {
+    IF_NOT_MULTIPLE_ERROR_RETURN(input_length, 4, NULL);
 
-	(*output_length) = input_length/4;
+    (*output_length) = input_length / 4;
 
-	int32_t* output = MALLOC_ARRAY(int32_t, (*output_length) );
+    int32_t* output = MALLOC_ARRAY(int32_t, (*output_length));
     IF_NULL_ALLOCERROR_RETURN_NULL(output);
 
-	array_copy_bigendian_4(output, input, input_length);
+    array_copy_bigendian_4(output, input, input_length);
 
-	return output;
+    return output;
 }
 
-char** MMTF_parser_strings_from_bytes( const char* input, uint32_t input_length, uint32_t parameter, uint32_t* output_length ) {
-	IF_NOT_MULTIPLE_ERROR_RETURN(input_length, parameter, NULL);
+char** MMTF_parser_strings_from_bytes(const char* input, uint32_t input_length, uint32_t parameter, uint32_t* output_length) {
+    IF_NOT_MULTIPLE_ERROR_RETURN(input_length, parameter, NULL);
 
-	(*output_length) = input_length / parameter;
+    (*output_length) = input_length / parameter;
 
-	char** output = MALLOC_ARRAY(char*, (*output_length) );
+    char** output = MALLOC_ARRAY(char*, (*output_length));
     IF_NULL_ALLOCERROR_RETURN_NULL(output);
 
-	uint32_t i;
-	for( i = 0; i < *output_length; ++i ) {
-		output[i] = MALLOC_ARRAY(char, parameter + 1);
+    uint32_t i;
+    for (i = 0; i < *output_length; ++i) {
+        output[i] = MALLOC_ARRAY(char, parameter + 1);
         IF_NULL_ALLOCERROR_RETURN_NULL(output[i]);
         memcpy(output[i], input + (i * parameter), parameter);
         output[i][parameter] = 0;
-	}
+    }
 
-	return output;
+    return output;
 }
-
 
 //*** Array decoders
 // Run-length decode
-int32_t* MMTF_parser_run_length_decode(const int32_t* input, uint32_t input_length, uint32_t* output_length ) {
-	(*output_length) = 0;
+int32_t* MMTF_parser_run_length_decode(const int32_t* input, uint32_t input_length, uint32_t* output_length) {
+    (*output_length) = 0;
 
-	IF_NOT_MULTIPLE_ERROR_RETURN(input_length, 2, NULL);
+    IF_NOT_MULTIPLE_ERROR_RETURN(input_length, 2, NULL);
 
-	uint32_t i;
-	int32_t value, number;
-	for(i = 0; i < input_length; i += 2) {
-		number = input[i+1];
+    uint32_t i;
+    int32_t value, number;
+    for (i = 0; i < input_length; i += 2) {
+        number = input[i + 1];
 
-		(*output_length) += number;
-	}
+        (*output_length) += number;
+    }
 
-	int32_t* output = MALLOC_ARRAY(int32_t, (*output_length)); // The output needs to be freed by the calling process
+    int32_t* output = MALLOC_ARRAY(int32_t, (*output_length)); // The output needs to be freed by the calling process
     IF_NULL_ALLOCERROR_RETURN_NULL(output);
 
-	int j = 0;
-	int k;
-	for(i = 0; i < input_length; i += 2) {
-		value = input[i];
-		number = input[i+1];
+    int j = 0;
+    int k;
+    for (i = 0; i < input_length; i += 2) {
+        value = input[i];
+        number = input[i + 1];
 
-		for(k = 0; k < number; ++k) {
-			output[j] = value;
-			++j;
-		}
-	}
+        for (k = 0; k < number; ++k) {
+            output[j] = value;
+            ++j;
+        }
+    }
 
-	return output;
+    return output;
 }
 
 // Delta decode
-int32_t* MMTF_parser_delta_decode(const int32_t* input, uint32_t input_length, uint32_t* output_length ) {
-	(*output_length) = input_length;
-	int32_t* output = MALLOC_ARRAY(int32_t, (*output_length)); // The output needs to be freed by the calling process
+int32_t* MMTF_parser_delta_decode(const int32_t* input, uint32_t input_length, uint32_t* output_length) {
+    (*output_length) = input_length;
+    int32_t* output = MALLOC_ARRAY(int32_t, (*output_length)); // The output needs to be freed by the calling process
     IF_NULL_ALLOCERROR_RETURN_NULL(output);
 
-	output[0] = input[0];
-	uint32_t i;
-	for(i = 1; i < input_length; ++i) {
-		output[i] = output[i-1] + input[i];
-	}
+    output[0] = input[0];
+    uint32_t i;
+    for (i = 1; i < input_length; ++i) {
+        output[i] = output[i - 1] + input[i];
+    }
 
-	return output;
+    return output;
 }
 
 // Recursive indexing decode
-int32_t* MMTF_parser_recursive_indexing_decode_from_16(const int16_t* input, uint32_t input_length, uint32_t* output_length ) {
-	(*output_length) = 0;
-	uint32_t i;
-	for( i = 0; i < input_length; ++i ) {
+int32_t* MMTF_parser_recursive_indexing_decode_from_16(const int16_t* input, uint32_t input_length, uint32_t* output_length) {
+    (*output_length) = 0;
+    uint32_t i;
+    for (i = 0; i < input_length; ++i) {
 
-		if( input[i] != INT16_MAX && input[i] != INT16_MIN ) {
-			++(*output_length);
-		}
-	}
+        if (input[i] != INT16_MAX && input[i] != INT16_MIN) {
+            ++(*output_length);
+        }
+    }
 
-	int32_t* output = (int32_t*) MALLOC_ARRAY(int32_t, (*output_length)); // The output needs to be freed by the calling process
+    int32_t* output = (int32_t*)MALLOC_ARRAY(int32_t, (*output_length)); // The output needs to be freed by the calling process
     IF_NULL_ALLOCERROR_RETURN_NULL(output);
 
-	int j = 0;
-	output[j] = 0;
+    int j = 0;
+    output[j] = 0;
 
-	for( i = 0; i < input_length; ++i ) {
-		output[j] += input[i];
+    for (i = 0; i < input_length; ++i) {
+        output[j] += input[i];
 
-		if( input[i] != INT16_MAX && input[i] != INT16_MIN && j+1 < *output_length ) {
-			++j;
-			output[j] = 0;
-		}
-	}
+        if (input[i] != INT16_MAX && input[i] != INT16_MIN && j + 1 < *output_length) {
+            ++j;
+            output[j] = 0;
+        }
+    }
 
-	return output;
+    return output;
 }
 
-int32_t* MMTF_parser_recursive_indexing_decode_from_8(const int8_t* input, uint32_t input_length, uint32_t* output_length ) {
-	(*output_length) = 0;
-	uint32_t i;
-	for( i = 0; i < input_length; ++i ) {
-		if( input[i] != INT8_MAX && input[i] != INT8_MIN ) {
-			++(*output_length);
-		}
-	}
+int32_t* MMTF_parser_recursive_indexing_decode_from_8(const int8_t* input, uint32_t input_length, uint32_t* output_length) {
+    (*output_length) = 0;
+    uint32_t i;
+    for (i = 0; i < input_length; ++i) {
+        if (input[i] != INT8_MAX && input[i] != INT8_MIN) {
+            ++(*output_length);
+        }
+    }
 
-	int32_t* output = MALLOC_ARRAY(int32_t, (*output_length)); // The output needs to be freed by the calling process
+    int32_t* output = MALLOC_ARRAY(int32_t, (*output_length)); // The output needs to be freed by the calling process
     IF_NULL_ALLOCERROR_RETURN_NULL(output);
 
-	int j = 0;
-	output[j] = 0;
+    int j = 0;
+    output[j] = 0;
 
-	for( i = 0; i < input_length; ++i ) {
-		output[j] += input[i];
+    for (i = 0; i < input_length; ++i) {
+        output[j] += input[i];
 
-		if( input[i] != INT8_MAX && input[i] != INT8_MIN && j+1 < *output_length ) {
-			++j;
-			output[j] = 0;
-		}
-	}
+        if (input[i] != INT8_MAX && input[i] != INT8_MIN && j + 1 < *output_length) {
+            ++j;
+            output[j] = 0;
+        }
+    }
 
-	return output;
+    return output;
 }
 
 // Integer decoding
-float* MMTF_parser_integer_decode_from_16(const int16_t* input, uint32_t input_length, int32_t parameter, uint32_t* output_length ) {
-	(*output_length) = input_length;
-	float* output = (float*) MALLOC_ARRAY(float, (*output_length) );
+float* MMTF_parser_integer_decode_from_16(const int16_t* input, uint32_t input_length, int32_t parameter, uint32_t* output_length) {
+    (*output_length) = input_length;
+    float* output = (float*)MALLOC_ARRAY(float, (*output_length));
     IF_NULL_ALLOCERROR_RETURN_NULL(output);
 
-	float parameter_float = (float) parameter;
-	uint32_t i;
-	for(i = 0; i < input_length; ++i ) {
-		output[i] = ((float) input[i])/parameter_float;
-	}
+    float parameter_float = (float)parameter;
+    uint32_t i;
+    for (i = 0; i < input_length; ++i) {
+        output[i] = ((float)input[i]) / parameter_float;
+    }
 
-	return output;
+    return output;
 }
 
-float* MMTF_parser_integer_decode_from_32(const int32_t* input, uint32_t input_length, int32_t parameter, uint32_t* output_length ) {
-	(*output_length) = input_length;
-	float* output = (float*) MALLOC_ARRAY(float, (*output_length) );
+float* MMTF_parser_integer_decode_from_32(const int32_t* input, uint32_t input_length, int32_t parameter, uint32_t* output_length) {
+    (*output_length) = input_length;
+    float* output = (float*)MALLOC_ARRAY(float, (*output_length));
     IF_NULL_ALLOCERROR_RETURN_NULL(output);
 
-	float parameter_float = (float) parameter;
-	uint32_t i;
-	for(i = 0; i < input_length; ++i ) {
-		output[i] = ((float) input[i])/parameter_float;
-	}
+    float parameter_float = (float)parameter;
+    uint32_t i;
+    for (i = 0; i < input_length; ++i) {
+        output[i] = ((float)input[i]) / parameter_float;
+    }
 
-	return output;
+    return output;
 }
-
 
 //*** Applying a decoding strategy for getting an array
 static
-void* MMTF_parser_decode_apply_strategy( const char* input,
+void* MMTF_parser_decode_apply_strategy(const char* input,
         uint32_t input_length, uint32_t* output_length, int strategy,
-        int32_t parameter, int * typecode) {
-	switch( strategy ) {
-		case 1:
-			*typecode = MMTF_TYPE_float;
-			return MMTF_parser_float_from_bytes( input, input_length, output_length );
-		case 2:
-			*typecode = MMTF_TYPE_int8;
-			return MMTF_parser_int8_from_bytes( input, input_length, output_length );
-		case 3:
-			*typecode = MMTF_TYPE_int16;
-			return MMTF_parser_int16_from_bytes( input, input_length, output_length );
-		case 4:
-			*typecode = MMTF_TYPE_int32;
-			return MMTF_parser_int32_from_bytes( input, input_length, output_length );
-		case 5:
-			*typecode = MMTF_TYPE_string;
-			return MMTF_parser_strings_from_bytes( input, input_length, parameter, output_length );
-		case 6: {
-            // pass
-		}
-		case 7: {
-			uint32_t step1_length;
-			int32_t* step1 = MMTF_parser_int32_from_bytes( input, input_length, &step1_length );
+        int32_t parameter, int* typecode) {
+    switch (strategy) {
+    case 1:
+        *typecode = MMTF_TYPE_float;
+        return MMTF_parser_float_from_bytes(input, input_length, output_length);
+    case 2:
+        *typecode = MMTF_TYPE_int8;
+        return MMTF_parser_int8_from_bytes(input, input_length, output_length);
+    case 3:
+        *typecode = MMTF_TYPE_int16;
+        return MMTF_parser_int16_from_bytes(input, input_length, output_length);
+    case 4:
+        *typecode = MMTF_TYPE_int32;
+        return MMTF_parser_int32_from_bytes(input, input_length, output_length);
+    case 5:
+        *typecode = MMTF_TYPE_string;
+        return MMTF_parser_strings_from_bytes(input, input_length, parameter, output_length);
+    case 6: {
+        // pass
+    }
+    case 7: {
+        uint32_t step1_length;
+        int32_t* step1 = MMTF_parser_int32_from_bytes(input, input_length, &step1_length);
 
-			int32_t* output = MMTF_parser_run_length_decode( step1, step1_length, output_length );
-			free(step1);
+        int32_t* output = MMTF_parser_run_length_decode(step1, step1_length, output_length);
+        free(step1);
 
-            if (strategy == 6) {
-                int i = 0;
-                char* char_output = MALLOC_ARRAY(char, (*output_length));
-                IF_NULL_ALLOCERROR_RETURN_NULL(char_output);
-                for (; i < *output_length; ++i) {
-                    char_output[i] = output[i];
-                }
-                free(output);
-
-				*typecode = MMTF_TYPE_int8;
-                return char_output;
+        if (strategy == 6) {
+            int i = 0;
+            char* char_output = MALLOC_ARRAY(char, (*output_length));
+            IF_NULL_ALLOCERROR_RETURN_NULL(char_output);
+            for (; i < *output_length; ++i) {
+                char_output[i] = output[i];
             }
+            free(output);
 
-			*typecode = MMTF_TYPE_int32;
-			return output;
-		}
-		case 8: {
-			uint32_t step1_length;
-			int32_t* step1 = MMTF_parser_int32_from_bytes( input, input_length, &step1_length );
+            *typecode = MMTF_TYPE_int8;
+            return char_output;
+        }
 
-			uint32_t step2_length;
-			int32_t* step2 = MMTF_parser_run_length_decode( step1, step1_length, &step2_length );
-			free(step1);
+        *typecode = MMTF_TYPE_int32;
+        return output;
+    }
+    case 8: {
+        uint32_t step1_length;
+        int32_t* step1 = MMTF_parser_int32_from_bytes(input, input_length, &step1_length);
 
-			int32_t* output = MMTF_parser_delta_decode( step2, step2_length, output_length );
-			free(step2);
+        uint32_t step2_length;
+        int32_t* step2 = MMTF_parser_run_length_decode(step1, step1_length, &step2_length);
+        free(step1);
 
-			*typecode = MMTF_TYPE_int32;
-			return output;
-		}
-		case 9: {
-			uint32_t step1_length;
-			int32_t* step1 = MMTF_parser_int32_from_bytes( input, input_length, &step1_length );
+        int32_t* output = MMTF_parser_delta_decode(step2, step2_length, output_length);
+        free(step2);
 
-			uint32_t step2_length;
-			int32_t* step2 = MMTF_parser_run_length_decode( step1, step1_length, &step2_length );
-			free(step1);
+        *typecode = MMTF_TYPE_int32;
+        return output;
+    }
+    case 9: {
+        uint32_t step1_length;
+        int32_t* step1 = MMTF_parser_int32_from_bytes(input, input_length, &step1_length);
 
-			float* output = MMTF_parser_integer_decode_from_32( step2, step2_length, parameter, output_length );
-			free(step2);
+        uint32_t step2_length;
+        int32_t* step2 = MMTF_parser_run_length_decode(step1, step1_length, &step2_length);
+        free(step1);
 
-			*typecode = MMTF_TYPE_float;
-			return output;
-		}
-		case 10: {
-			uint32_t step1_length;
-			int16_t* step1 = MMTF_parser_int16_from_bytes( input, input_length, &step1_length );
+        float* output = MMTF_parser_integer_decode_from_32(step2, step2_length, parameter, output_length);
+        free(step2);
 
-			uint32_t step2_length;
-			int32_t* step2 = MMTF_parser_recursive_indexing_decode_from_16( step1, step1_length, &step2_length );
-			free(step1);
+        *typecode = MMTF_TYPE_float;
+        return output;
+    }
+    case 10: {
+        uint32_t step1_length;
+        int16_t* step1 = MMTF_parser_int16_from_bytes(input, input_length, &step1_length);
 
-			uint32_t step3_length;
-			int32_t* step3 = MMTF_parser_delta_decode( step2, step2_length, &step3_length );
-			free(step2);
+        uint32_t step2_length;
+        int32_t* step2 = MMTF_parser_recursive_indexing_decode_from_16(step1, step1_length, &step2_length);
+        free(step1);
 
-			float* output = MMTF_parser_integer_decode_from_32( step3, step3_length, parameter, output_length );
-			free(step3);
+        uint32_t step3_length;
+        int32_t* step3 = MMTF_parser_delta_decode(step2, step2_length, &step3_length);
+        free(step2);
 
-			*typecode = MMTF_TYPE_float;
-			return output;
-		}
-		case 11: {
-			uint32_t step1_length;
-			int16_t* step1 = MMTF_parser_int16_from_bytes( input, input_length, &step1_length );
+        float* output = MMTF_parser_integer_decode_from_32(step3, step3_length, parameter, output_length);
+        free(step3);
 
-			float* output = MMTF_parser_integer_decode_from_16( step1, step1_length, parameter, output_length );
-			free(step1);
+        *typecode = MMTF_TYPE_float;
+        return output;
+    }
+    case 11: {
+        uint32_t step1_length;
+        int16_t* step1 = MMTF_parser_int16_from_bytes(input, input_length, &step1_length);
 
-			*typecode = MMTF_TYPE_float;
-			return output;
-		}
-		case 12: {
-			uint32_t step1_length;
-			int16_t* step1 = MMTF_parser_int16_from_bytes( input, input_length, &step1_length );
+        float* output = MMTF_parser_integer_decode_from_16(step1, step1_length, parameter, output_length);
+        free(step1);
 
-			uint32_t step2_length;
-			int32_t* step2 = MMTF_parser_recursive_indexing_decode_from_16( step1, step1_length, &step2_length );
-			free(step1);
+        *typecode = MMTF_TYPE_float;
+        return output;
+    }
+    case 12: {
+        uint32_t step1_length;
+        int16_t* step1 = MMTF_parser_int16_from_bytes(input, input_length, &step1_length);
 
-			float* output = MMTF_parser_integer_decode_from_32( step2, step2_length, parameter, output_length );
-			free(step2);
+        uint32_t step2_length;
+        int32_t* step2 = MMTF_parser_recursive_indexing_decode_from_16(step1, step1_length, &step2_length);
+        free(step1);
 
-			*typecode = MMTF_TYPE_float;
-			return output;
-		}
-		case 13: {
-			uint32_t step1_length;
-			int8_t* step1 = MMTF_parser_int8_from_bytes( input, input_length, &step1_length );
+        float* output = MMTF_parser_integer_decode_from_32(step2, step2_length, parameter, output_length);
+        free(step2);
 
-			uint32_t step2_length;
-			int32_t* step2 = MMTF_parser_recursive_indexing_decode_from_8( step1, step1_length, &step2_length );
-			free(step1);
+        *typecode = MMTF_TYPE_float;
+        return output;
+    }
+    case 13: {
+        uint32_t step1_length;
+        int8_t* step1 = MMTF_parser_int8_from_bytes(input, input_length, &step1_length);
 
-			float* output = MMTF_parser_integer_decode_from_32( step2, step2_length, parameter, output_length );
-			free(step2);
+        uint32_t step2_length;
+        int32_t* step2 = MMTF_parser_recursive_indexing_decode_from_8(step1, step1_length, &step2_length);
+        free(step1);
 
-			*typecode = MMTF_TYPE_float;
-			return output;
-		}
-		case 14: {
-			uint32_t step1_length;
-			int16_t* step1 = MMTF_parser_int16_from_bytes( input, input_length, &step1_length );
+        float* output = MMTF_parser_integer_decode_from_32(step2, step2_length, parameter, output_length);
+        free(step2);
 
-			int32_t* output = MMTF_parser_recursive_indexing_decode_from_16( step1, step1_length, output_length );
-			free(step1);
+        *typecode = MMTF_TYPE_float;
+        return output;
+    }
+    case 14: {
+        uint32_t step1_length;
+        int16_t* step1 = MMTF_parser_int16_from_bytes(input, input_length, &step1_length);
 
-			*typecode = MMTF_TYPE_int32;
-			return output;
-		}
-		case 15: {
-			uint32_t step1_length;
-			int8_t* step1 = MMTF_parser_int8_from_bytes( input, input_length, &step1_length );
+        int32_t* output = MMTF_parser_recursive_indexing_decode_from_16(step1, step1_length, output_length);
+        free(step1);
 
-			int32_t* output = MMTF_parser_recursive_indexing_decode_from_8( step1, step1_length, output_length );
-			free(step1);
+        *typecode = MMTF_TYPE_int32;
+        return output;
+    }
+    case 15: {
+        uint32_t step1_length;
+        int8_t* step1 = MMTF_parser_int8_from_bytes(input, input_length, &step1_length);
 
-			*typecode = MMTF_TYPE_int32;
-			return output;
-		}
-		default: {
-			fprintf( stderr, "Error in %s: %i does not refer to any strategy.\n", __FUNCTION__, strategy );
-			return NULL;
-		}
-	}
+        int32_t* output = MMTF_parser_recursive_indexing_decode_from_8(step1, step1_length, output_length);
+        free(step1);
+
+        *typecode = MMTF_TYPE_int32;
+        return output;
+    }
+    default: {
+        fprintf(stderr, "Error in %s: %i does not refer to any strategy.\n", __FUNCTION__, strategy);
+        return NULL;
+    }
+    }
 }
 
 /*
@@ -702,83 +710,79 @@ void* MMTF_parser_decode_apply_strategy( const char* input,
 static
 void MMTF_parser_put_string(const msgpack_object* object, char** out) {
     size_t string_size = object->via.str.size;
-    char * result = (*out) = MALLOC_ARRAY(char, (string_size + 1));
-    IF_NULL_ALLOCERROR_RETURN(result,);
+    char* result = (*out) = MALLOC_ARRAY(char, (string_size + 1));
+    IF_NULL_ALLOCERROR_RETURN(result, );
     memcpy(result, object->via.str.ptr, string_size);
     result[string_size] = '\0';
 }
 
 //*** Unpacking from MsgPack and applying strategy
-char* MMTF_parser_fetch_string( const msgpack_object* object ) {
-	if( object->type != MMTF_MSGPACK_TYPE(STR) ) {
-		fprintf( stderr, "Error in %s: the entry encoded in the MMTF is not a string.\n", __FUNCTION__ );
-		return NULL;
-	}
-
-    char * result = NULL;
-    MMTF_parser_put_string(object, &result);
-	return result;
-}
-
-char MMTF_parser_fetch_char( const msgpack_object* object ) {
-	if( object->type != MMTF_MSGPACK_TYPE(STR)) {
-		fprintf( stderr, "Error in %s: the entry encoded in the MMTF is not a string.\n", __FUNCTION__ );
-		return '\0';
-	}
-
-	return *(object->via.str.ptr);
-}
-
-int64_t MMTF_parser_fetch_int( const msgpack_object* object ) {
-	int64_t result;
-
-    if(object->type == MMTF_MSGPACK_TYPE(POSITIVE_INTEGER)) {
-        result = object->via.u64;
+char* MMTF_parser_fetch_string(const msgpack_object* object) {
+    if (object->type != MMTF_MSGPACK_TYPE(STR)) {
+        fprintf(stderr, "Error in %s: the entry encoded in the MMTF is not a string.\n", __FUNCTION__);
+        return NULL;
     }
-    else if(object->type == MMTF_MSGPACK_TYPE(NEGATIVE_INTEGER)) {
-        result = object->via.i64;
-	}
-	else {
-		fprintf( stderr, "Error in %s: the entry encoded in the MMTF is not an integer.\n", __FUNCTION__ );
-		return NAN;
-	}
 
-	return result;
+    char* result = NULL;
+    MMTF_parser_put_string(object, &result);
+    return result;
 }
 
-float MMTF_parser_fetch_float( const msgpack_object* object ) {
-	if( object->type != MMTF_MSGPACK_TYPE(FLOAT) ) {
-		fprintf( stderr, "Error in %s: the entry encoded in the MMTF is not a float.\n", __FUNCTION__ );
-		return NAN;
-	}
-	
-	return (float) object->via.f64;
+char MMTF_parser_fetch_char(const msgpack_object* object) {
+    if (object->type != MMTF_MSGPACK_TYPE(STR)) {
+        fprintf(stderr, "Error in %s: the entry encoded in the MMTF is not a string.\n", __FUNCTION__);
+        return '\0';
+    }
+
+    return *(object->via.str.ptr);
+}
+
+int64_t MMTF_parser_fetch_int(const msgpack_object* object) {
+    int64_t result;
+
+    if (object->type == MMTF_MSGPACK_TYPE(POSITIVE_INTEGER)) {
+        result = object->via.u64;
+    } else if (object->type == MMTF_MSGPACK_TYPE(NEGATIVE_INTEGER)) {
+        result = object->via.i64;
+    } else {
+        fprintf(stderr, "Error in %s: the entry encoded in the MMTF is not an integer.\n", __FUNCTION__);
+        return NAN;
+    }
+
+    return result;
+}
+
+float MMTF_parser_fetch_float(const msgpack_object* object) {
+    if (object->type != MMTF_MSGPACK_TYPE(FLOAT)) {
+        fprintf(stderr, "Error in %s: the entry encoded in the MMTF is not a float.\n", __FUNCTION__);
+        return NAN;
+    }
+
+    return (float)object->via.f64;
 }
 
 /*
  * Fetch a compressed typed array
  */
 static
-void* MMTF_parser_fetch_typed_array( const msgpack_object* object, size_t* length, int typecode) {
-	if( object->type != MMTF_MSGPACK_TYPE(BIN) ) {
-		fprintf( stderr, "Error in %s: the entry encoded in the MMTF is not binary data.\n", __FUNCTION__ );
-		return NULL;
-	}
+void* MMTF_parser_fetch_typed_array(const msgpack_object* object, size_t* length, int typecode) {
+    if (object->type != MMTF_MSGPACK_TYPE(BIN)) {
+        fprintf(stderr, "Error in %s: the entry encoded in the MMTF is not binary data.\n", __FUNCTION__);
+        return NULL;
+    }
 
-	const char* bytes = object->via.bin.ptr;
+    const char* bytes = object->via.bin.ptr;
 
-	int32_t strategy, len_int32, parameter;
-	assign_bigendian_4(&strategy,   bytes);
-	assign_bigendian_4(&len_int32,  bytes + 4);
-	assign_bigendian_4(&parameter,  bytes + 8);
+    int32_t strategy, len_int32, parameter;
+    assign_bigendian_4(&strategy, bytes);
+    assign_bigendian_4(&len_int32, bytes + 4);
+    assign_bigendian_4(&parameter, bytes + 8);
 
-	*length = len_int32;
-
-//printf( "Applying the strategy %i with parameter %i for decoding a byte array of length %i into an int32 array of length %lu.\n", strategy, parameter, object->via.bin.size - 12, *length );
+    *length = len_int32;
 
     uint32_t out_length;
     int typecheck;
-    void * result = MMTF_parser_decode_apply_strategy(bytes + 12,
+    void* result = MMTF_parser_decode_apply_strategy(bytes + 12,
             object->via.bin.size - 12, &out_length, strategy, parameter,
             &typecheck);
 
@@ -790,7 +794,7 @@ void* MMTF_parser_fetch_typed_array( const msgpack_object* object, size_t* lengt
 
     if (out_length != *length) {
         fprintf(stderr, "Error in %s: length mismatch %u %u\n",
-                __FUNCTION__, out_length, (unsigned) *length);
+                __FUNCTION__, out_length, (unsigned)*length);
         return NULL;
     }
 
@@ -800,18 +804,20 @@ void* MMTF_parser_fetch_typed_array( const msgpack_object* object, size_t* lengt
 /*
  * Fetch a typed array.
  */
+// clang-format off
 CODEGEN_MMTF_parser_fetch_array(char,   result[i] = iter->via.u64)
 CODEGEN_MMTF_parser_fetch_array(int8,   result[i] = iter->via.u64)
 CODEGEN_MMTF_parser_fetch_array(int32,  result[i] = iter->via.u64)
 CODEGEN_MMTF_parser_fetch_array(float,  result[i] = iter->via.f64)
 CODEGEN_MMTF_parser_fetch_array(string, MMTF_parser_put_string(iter, result + i))
 
-bool MMTF_parser_compare_msgpack_string_char_array( const msgpack_object_str* m_string, const char* string ) {
-	return (m_string->size == strlen( string ) && strncmp( m_string->ptr, string, m_string->size ) == 0);
+bool MMTF_parser_compare_msgpack_string_char_array(const msgpack_object_str* m_string, const char* string) {
+    // clang-format on
+    return (m_string->size == strlen(string) && strncmp(m_string->ptr, string, m_string->size) == 0);
 }
 
 static
-void MMTF_parser_put_entity( const msgpack_object* object, MMTF_Entity* entity ) {
+void MMTF_parser_put_entity(const msgpack_object* object, MMTF_Entity* entity) {
     MAP_ITERATE_BEGIN(object);
     FETCH_AND_ASSIGN(entity, string, description);
     FETCH_AND_ASSIGN(entity, string, type);
@@ -821,7 +827,7 @@ void MMTF_parser_put_entity( const msgpack_object* object, MMTF_Entity* entity )
 }
 
 static
-void MMTF_parser_put_group( const msgpack_object* object, MMTF_GroupType* group_type ) {
+void MMTF_parser_put_group(const msgpack_object* object, MMTF_GroupType* group_type) {
     MAP_ITERATE_BEGIN(object);
     FETCH_AND_ASSIGN_DUMMYCOUNT(group_type, int32_array, formalChargeList);
     FETCH_AND_ASSIGN_WITHCOUNT(group_type, string_array, atomNameList);
@@ -835,7 +841,7 @@ void MMTF_parser_put_group( const msgpack_object* object, MMTF_GroupType* group_
 }
 
 static
-void MMTF_parser_put_bioAssembly( const msgpack_object* object, MMTF_BioAssembly* bio_assembly ) {
+void MMTF_parser_put_bioAssembly(const msgpack_object* object, MMTF_BioAssembly* bio_assembly) {
     MAP_ITERATE_BEGIN(object);
     FETCH_AND_ASSIGN(bio_assembly, string, name);
     FETCH_AND_ASSIGN_WITHCOUNT(bio_assembly, transformList, transformList);
@@ -843,19 +849,21 @@ void MMTF_parser_put_bioAssembly( const msgpack_object* object, MMTF_BioAssembly
 }
 
 static
-void MMTF_parser_put_transform( const msgpack_object* object, MMTF_Transform* transform ) {
+void MMTF_parser_put_transform(const msgpack_object* object, MMTF_Transform* transform) {
     MAP_ITERATE_BEGIN(object);
     FETCH_AND_ASSIGN_WITHCOUNT(transform, int32_array, chainIndexList);
     FETCH_AND_ASSIGN_ARRAY(transform, float, matrix);
     MAP_ITERATE_END();
 }
 
+// clang-format off
 CODEGEN_MMTF_parser_fetch_List(MMTF_Entity, entity)
 CODEGEN_MMTF_parser_fetch_List(MMTF_GroupType, group)
 CODEGEN_MMTF_parser_fetch_List(MMTF_BioAssembly, bioAssembly)
 CODEGEN_MMTF_parser_fetch_List(MMTF_Transform, transform)
 
 void MMTF_parser_msgpack_object_to_MMTF_container(const msgpack_object* object, MMTF_container* thing) {
+    // clang-format on
     MAP_ITERATE_BEGIN(object);
     FETCH_AND_ASSIGN(thing, string, mmtfVersion);
     FETCH_AND_ASSIGN(thing, string, mmtfProducer);
@@ -898,7 +906,7 @@ void MMTF_parser_msgpack_object_to_MMTF_container(const msgpack_object* object, 
     MAP_ITERATE_END();
 }
 
-void MMTF_unpack_from_string(const char *buffer, size_t msgsize, MMTF_container* thing){
+void MMTF_unpack_from_string(const char* buffer, size_t msgsize, MMTF_container* thing) {
 #ifdef MMTF_MSGPACK_USE_CPP11
 
     msgpack::object_handle oh = msgpack::unpack(buffer, msgsize);
@@ -910,57 +918,48 @@ void MMTF_unpack_from_string(const char *buffer, size_t msgsize, MMTF_container*
     msgpack_zone mempool;
     msgpack_zone_init(&mempool, 2048);
     msgpack_object deserialized;
-	msgpack_unpack(buffer, msgsize, NULL, &mempool, &deserialized);
-
-//printf( "msgpack_object unpacked\n" );
+    msgpack_unpack(buffer, msgsize, NULL, &mempool, &deserialized);
 
     MMTF_parser_msgpack_object_to_MMTF_container(&deserialized, thing);
-
-//printf( "MMTF structure decoded\n" );
 
     msgpack_zone_destroy(&mempool);
 
 #endif
 }
 
-
 //*** Decode a MMTF container from a file
-void MMTF_unpack_from_file(const char *name, MMTF_container* thing)
-{
-	FILE *file;
-	char *buffer;
-	size_t fileLen;
+void MMTF_unpack_from_file(const char* name, MMTF_container* thing) {
+    FILE* file;
+    char* buffer;
+    size_t fileLen;
 
-//*** Open file
-	file = fopen(name, "rb");
-	if (!file) {
-		fprintf(stderr, "Error in %s: unable to open file %s.\n", __FUNCTION__, name);
-		return;
-	}
+    //*** Open file
+    file = fopen(name, "rb");
+    if (!file) {
+        fprintf(stderr, "Error in %s: unable to open file %s.\n", __FUNCTION__, name);
+        return;
+    }
 
-//*** Get file length
-	fseek(file, 0, SEEK_END);
-	fileLen = ftell(file);
-	fseek(file, 0, SEEK_SET);
+    //*** Get file length
+    fseek(file, 0, SEEK_END);
+    fileLen = ftell(file);
+    fseek(file, 0, SEEK_SET);
 
-//printf("File length = %lu\n", fileLen);
-
-//*** Allocate memory
-	buffer=(char *)malloc(fileLen+1);
-	if (!buffer)
-	{
-		fprintf(stderr, "Error in %s: couldn't allocate memory.\n", __FUNCTION__);
+    //*** Allocate memory
+    buffer = (char*)malloc(fileLen + 1);
+    if (!buffer) {
+        fprintf(stderr, "Error in %s: couldn't allocate memory.\n", __FUNCTION__);
         fclose(file);
-		return;
-	}
+        return;
+    }
 
-//*** Read file contents into buffer
-	fread(buffer, fileLen, 1, file);
-	fclose(file);
+    //*** Read file contents into buffer
+    fread(buffer, fileLen, 1, file);
+    fclose(file);
 
-	MMTF_unpack_from_string(buffer, fileLen, thing);
+    MMTF_unpack_from_string(buffer, fileLen, thing);
 
-	free(buffer);
+    free(buffer);
 }
 
-// vi:sw=4:ts=4
+// vi:sw=4:expandtab

--- a/src/mmtf_parser.c
+++ b/src/mmtf_parser.c
@@ -812,6 +812,7 @@ CODEGEN_MMTF_parser_fetch_array(int32,  result[i] = iter->via.u64)
 CODEGEN_MMTF_parser_fetch_array(float,  result[i] = iter->via.f64)
 CODEGEN_MMTF_parser_fetch_array(string, MMTF_parser_put_string(iter, result + i))
 
+static
 bool MMTF_parser_compare_msgpack_string_char_array(const msgpack_object_str* m_string, const char* string) {
     // clang-format on
     return (m_string->size == strlen(string) && strncmp(m_string->ptr, string, m_string->size) == 0);
@@ -863,6 +864,7 @@ CODEGEN_MMTF_parser_fetch_List(MMTF_GroupType, group)
 CODEGEN_MMTF_parser_fetch_List(MMTF_BioAssembly, bioAssembly)
 CODEGEN_MMTF_parser_fetch_List(MMTF_Transform, transform)
 
+static
 void MMTF_parser_msgpack_object_to_MMTF_container(const msgpack_object* object, MMTF_container* thing) {
     // clang-format on
     int version_major;

--- a/src/mmtf_parser.c
+++ b/src/mmtf_parser.c
@@ -107,8 +107,10 @@ enum {
         for (; current_key_value != last_key_value; ++current_key_value) { \
             const msgpack_object* key = &(current_key_value->key); \
             const msgpack_object* value = &(current_key_value->val); \
-            if (key->type != MMTF_MSGPACK_TYPE(STR)) \
-                continue;
+            if (key->type != MMTF_MSGPACK_TYPE(STR)) { \
+                fprintf(stderr, "Warning: map key not of type str (type %d).\n", key->type); \
+                continue; \
+            }
 
 #define MAP_ITERATE_END() \
     } \

--- a/src/mmtf_parser.c
+++ b/src/mmtf_parser.c
@@ -1,28 +1,28 @@
-//***************************************************************************************************
-//******	Copyright [2016] [RCSB]
-//******
-//******	Licensed under the Apache License, Version 2.0 (the "License");
-//******	you may not use this file except in compliance with the License.
-//******	You may obtain a copy of the License at
-//******
-//******	    http://www.apache.org/licenses/LICENSE-2.0
-//******
-//******	Unless required by applicable law or agreed to in writing, software
-//******	distributed under the License is distributed on an "AS IS" BASIS,
-//******	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//******	See the License for the specific language governing permissions and
-//******	limitations under the License.
-//******
-//******
-//******	This file is mmtf_parser.c, holding the source code of the MMTF parser
-//******	for the C language.
-//******
-//******	The authors of this code are Julien Ferté (http://www.julienferte.com/),
-//******	Anthony Bradley, Thomas Holder.
-//******
-//******	Other contributors: Yana Valasatava, Gazal Kalyan, Alexander Rose.
-//******
-//************************************************************************************************
+// *************************************************************************
+// Copyright [2016] [RCSB]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+// This file is mmtf_parser.c, holding the source code of the MMTF parser
+//
+// The authors of this code are: Julien Ferte (http://www.julienferte.com/),
+// Anthony Bradley, Thomas Holder.
+//
+//
+// Other contributors: Yana Valasatava, Gazal Kalyan, Alexander Rose.
+//
+// *************************************************************************
 
 #define WIN32_LEAN_AND_MEAN
 
@@ -906,6 +906,9 @@ void MMTF_parser_msgpack_object_to_MMTF_container(const msgpack_object* object, 
     MAP_ITERATE_END();
 }
 
+/*
+ * Decode a MMTF_container from a string
+ */
 void MMTF_unpack_from_string(const char* buffer, size_t msgsize, MMTF_container* thing) {
 #ifdef MMTF_MSGPACK_USE_CPP11
 
@@ -927,7 +930,9 @@ void MMTF_unpack_from_string(const char* buffer, size_t msgsize, MMTF_container*
 #endif
 }
 
-//*** Decode a MMTF container from a file
+/*
+ * Decode a MMTF container from a file
+ */
 void MMTF_unpack_from_file(const char* name, MMTF_container* thing) {
     FILE* file;
     char* buffer;

--- a/src/mmtf_parser.h
+++ b/src/mmtf_parser.h
@@ -24,69 +24,69 @@
 //******
 //*******************************************************************************
 
-
 #ifndef MMTF_PARSER_H
 #define MMTF_PARSER_H
 
 //*** Standard libs
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-
-#define WITHCOUNT(name) name; size_t name ## Count
+#define WITHCOUNT(name) \
+    name; \
+    size_t name##Count
 
 //*** The MMTF structure
-    /** @brief Group (residue) level data store */
+/** @brief Group (residue) level data store */
 typedef struct {
-    int32_t *			formalChargeList;           /**< formalChargeList List of formal charges as Integers */
-    char **				WITHCOUNT(atomNameList);    /**< List of atom names, 0 to 5 character Strings*/
-    char **				WITHCOUNT(elementList);     /**< List of elements, 0 to 3 character Strings */
-    int32_t *			WITHCOUNT(bondAtomList);    /**< List of bonded atom indices, Integers */
-    int8_t *			WITHCOUNT(bondOrderList);   /**< List of bond orders as Integers between 1 and 4 */
-    char *				groupName;           /**< The name of the group, 0 to 5 characters */
-    char				singleLetterCode;    /**< The single letter code, 1 character */
-    char *				chemCompType;        /**< The chemical component type */
+    int32_t* formalChargeList;        /**< formalChargeList List of formal charges as Integers */
+    char** WITHCOUNT(atomNameList);   /**< List of atom names, 0 to 5 character Strings*/
+    char** WITHCOUNT(elementList);    /**< List of elements, 0 to 3 character Strings */
+    int32_t* WITHCOUNT(bondAtomList); /**< List of bonded atom indices, Integers */
+    int8_t* WITHCOUNT(bondOrderList); /**< List of bond orders as Integers between 1 and 4 */
+    char* groupName;                  /**< The name of the group, 0 to 5 characters */
+    char singleLetterCode;            /**< The single letter code, 1 character */
+    char* chemCompType;               /**< The chemical component type */
 } MMTF_GroupType;
 
-    /** @brief An Entity is defined as each of the distinct molecules present in a PDB structure. It can be of type polymer, non-polymer, macrolide or water */
+/** @brief An Entity is defined as each of the distinct molecules present in a PDB structure. It can be of type polymer, non-polymer, macrolide or water */
 typedef struct {
-    int32_t *			WITHCOUNT(chainIndexList);   /**< Indices of fields in chainIdList and chainNameList fields */
-    char *				description;    /**< Description of the entity */
-    char *				type;           /**< Name of the entity type */
-    char *				sequence;       /**< Sequence of the full construct in one-letter-code */
+    int32_t* WITHCOUNT(chainIndexList); /**< Indices of fields in chainIdList and chainNameList fields */
+    char* description;                  /**< Description of the entity */
+    char* type;                         /**< Name of the entity type */
+    char* sequence;                     /**< Sequence of the full construct in one-letter-code */
 } MMTF_Entity;
 
-	/** @brief The transformation needed for generation of biological assemblies from the contents of a PDB/mmCIF file. It contains both the actual transformation (rotation+translation) and the chain identifier to which it should be applied */
+/** @brief The transformation needed for generation of biological assemblies from the contents of a PDB/mmCIF file. It contains both the actual transformation (rotation+translation) and the chain identifier to which it should be applied */
 typedef struct {
-    int32_t *			WITHCOUNT(chainIndexList);  /**< Indices of fields in chainIdList and chainNameList fields */
-    float				matrix[16];                 /**< 4X4 Transformation matrix  */
+    int32_t* WITHCOUNT(chainIndexList); /**< Indices of fields in chainIdList and chainNameList fields */
+    float matrix[16];                   /**< 4X4 Transformation matrix  */
 } MMTF_Transform;
 
-	/** @brief Data store for the biological assembly annotation as provided by the PDB. Contains all the information required to build the Biological Assembly from the asymmetric unit */
+/** @brief Data store for the biological assembly annotation as provided by the PDB. Contains all the information required to build the Biological Assembly from the asymmetric unit */
 typedef struct {
-    MMTF_Transform*		WITHCOUNT(transformList);   /**< List of MMTF_transform objects */
-    char*				name;                       /**< Name of the biological assembly */
+    MMTF_Transform* WITHCOUNT(transformList); /**< List of MMTF_transform objects */
+    char* name;                               /**< Name of the biological assembly */
 } MMTF_BioAssembly;
 
-    /** @brief MMTF container holds the MMTF data */
+/** @brief MMTF container holds the MMTF data */
 
 typedef struct {
-    char *				mmtfVersion;    /**< The version of MMTF */
-    char *				mmtfProducer;   /**< The producer of MMTF */
-    float				unitCell[6];    /**< Array of 6 defining the unit cell: a, b, c, alpha, beta, gamma */
-    char *				spaceGroup;     /**< the space group name */
-    char *				structureId;    /**< An ID for the structure, for eg. the 4 letter PDB ID */
-    char *				title;          /**< description of the structural data included in the file */
-    char *				depositionDate; /**< Date of the deposition of the structure in a database in format YYY-MM-DD */
-    char *				releaseDate;    /**< Date of release of the structure in the database in format YYY-MM-DD */
-    MMTF_BioAssembly*	WITHCOUNT(bioAssemblyList); /**< List of MMTF_BioAssembly objects */
-    MMTF_Entity *		WITHCOUNT(entityList);      /**< List of MMTF_Entity objects */
-    char **				WITHCOUNT(experimentalMethods);
-                            /**< experimentalMethods is a character array of unknown length so we
+    char* mmtfVersion;                            /**< The version of MMTF */
+    char* mmtfProducer;                           /**< The producer of MMTF */
+    float unitCell[6];                            /**< Array of 6 defining the unit cell: a, b, c, alpha, beta, gamma */
+    char* spaceGroup;                             /**< the space group name */
+    char* structureId;                            /**< An ID for the structure, for eg. the 4 letter PDB ID */
+    char* title;                                  /**< description of the structural data included in the file */
+    char* depositionDate;                         /**< Date of the deposition of the structure in a database in format YYY-MM-DD */
+    char* releaseDate;                            /**< Date of release of the structure in the database in format YYY-MM-DD */
+    MMTF_BioAssembly* WITHCOUNT(bioAssemblyList); /**< List of MMTF_BioAssembly objects */
+    MMTF_Entity* WITHCOUNT(entityList);           /**< List of MMTF_Entity objects */
+    char** WITHCOUNT(experimentalMethods);
+    /**< experimentalMethods is a character array of unknown length so we
                              * need to specify the number of elements. String must be one of the
                              * following: \n
                              *  ELECTRON CRYSTALLOGRAPHY \n
@@ -103,34 +103,34 @@ typedef struct {
                              *  THEORETICAL MODEL \n
                              *  X-RAY DIFFRACTION
                              */
-    size_t				numberOfExperimentalMethods; /**< The number of experimental methods for the structure */
-    float				resolution; /**< Resolution of the structure */
-    float				rFree;      /**< Rfree of the structure. Used to assess possible overmodelling of the data */
-    float				rWork;      /**< Rwork of the structure. Used to assess the agreement between the crystallographic model and the experimental X-ray diffraction data */
-    int32_t				numBonds;   /**< Total number of bonds in the structure */
-    int32_t				numAtoms;   /**< Total number of atoms in the structure */
-    int32_t				numGroups;  /**< Total number of groups (residues) in the structure */
-    int32_t				numChains;  /**< Total number of chains in the structure */
-    int32_t				numModels;  /**< Total number of models in the structure */
-    MMTF_GroupType *	WITHCOUNT(groupList);     /**< List of MMTF_GroupType objects */
-    int32_t *			WITHCOUNT(bondAtomList);  /**< Pairs of values represent indices of covalently bonded atoms */
-    int8_t *			WITHCOUNT(bondOrderList); /**< 8 bit signed integer */
-    float *				xCoordList;     /**< List of x coordinates */
-    float *				yCoordList;     /**< List of y coordinates */
-    float *				zCoordList;     /**< List of z coordinates */
-    float *				bFactorList;    /**< List of Bfactors */
-    int32_t *           atomIdList;     /**< List of atom serial numbers */
-    char *				altLocList;     /**< List of alternate locations */
-    float *				occupancyList;  /**< List of occupancies */
-    int32_t *			groupIdList;    /**< List of groups (residues) */
-    int32_t *			groupTypeList;
-    int8_t *			secStructList;  /**< List of of secondary structure assignments. See [specification](https://github.com/rcsb/mmtf/blob/v1.0/spec.md#secstructlist) */
-    char *				insCodeList;    /**< List of insertion codes */
-    int32_t *			sequenceIndexList;
-    char **				WITHCOUNT(chainIdList);     /**< Array of 4-char strings */
-    char **				WITHCOUNT(chainNameList);   /**< Array of 4-char strings */
-    int32_t *			groupsPerChain; /**< List of total number of groups in each chain */
-    int32_t *			chainsPerModel; /**< List of total number of chains in each model */
+    size_t numberOfExperimentalMethods;   /**< The number of experimental methods for the structure */
+    float resolution;                     /**< Resolution of the structure */
+    float rFree;                          /**< Rfree of the structure. Used to assess possible overmodelling of the data */
+    float rWork;                          /**< Rwork of the structure. Used to assess the agreement between the crystallographic model and the experimental X-ray diffraction data */
+    int32_t numBonds;                     /**< Total number of bonds in the structure */
+    int32_t numAtoms;                     /**< Total number of atoms in the structure */
+    int32_t numGroups;                    /**< Total number of groups (residues) in the structure */
+    int32_t numChains;                    /**< Total number of chains in the structure */
+    int32_t numModels;                    /**< Total number of models in the structure */
+    MMTF_GroupType* WITHCOUNT(groupList); /**< List of MMTF_GroupType objects */
+    int32_t* WITHCOUNT(bondAtomList);     /**< Pairs of values represent indices of covalently bonded atoms */
+    int8_t* WITHCOUNT(bondOrderList);     /**< 8 bit signed integer */
+    float* xCoordList;                    /**< List of x coordinates */
+    float* yCoordList;                    /**< List of y coordinates */
+    float* zCoordList;                    /**< List of z coordinates */
+    float* bFactorList;                   /**< List of Bfactors */
+    int32_t* atomIdList;                  /**< List of atom serial numbers */
+    char* altLocList;                     /**< List of alternate locations */
+    float* occupancyList;                 /**< List of occupancies */
+    int32_t* groupIdList;                 /**< List of groups (residues) */
+    int32_t* groupTypeList;
+    int8_t* secStructList; /**< List of of secondary structure assignments. See [specification](https://github.com/rcsb/mmtf/blob/v1.0/spec.md#secstructlist) */
+    char* insCodeList;     /**< List of insertion codes */
+    int32_t* sequenceIndexList;
+    char** WITHCOUNT(chainIdList);   /**< Array of 4-char strings */
+    char** WITHCOUNT(chainNameList); /**< Array of 4-char strings */
+    int32_t* groupsPerChain;         /**< List of total number of groups in each chain */
+    int32_t* chainsPerModel;         /**< List of total number of chains in each model */
 } MMTF_container;
 
 /**
@@ -138,16 +138,18 @@ typedef struct {
  */
 
 #define CODEGEN_MMTF_parser_TYPE(type) \
-    type * type ## _new(void); \
-    void   type ## _init(type *); \
-    void   type ## _destroy(type *); \
-    void   type ## _clear(type *); \
-    void   type ## _free(type *);
+    type* type##_new(void); \
+    void type##_init(type*); \
+    void type##_destroy(type*); \
+    void type##_clear(type*); \
+    void type##_free(type*);
+
 /**
  * @fn MMTF_container_free(MMTF_container* thing)
  * @param thing The MMTF_container to be freed
  * @return void
  */
+// clang-format off
 CODEGEN_MMTF_parser_TYPE(MMTF_container)
 CODEGEN_MMTF_parser_TYPE(MMTF_BioAssembly)
 CODEGEN_MMTF_parser_TYPE(MMTF_Transform)
@@ -156,28 +158,27 @@ CODEGEN_MMTF_parser_TYPE(MMTF_GroupType)
 
 #undef CODEGEN_MMTF_parser_TYPE
 
+/* MMTF and MsgPack */
 
-    /* MMTF and MsgPack */
+/**
+ * @fn void MMTF_unpack_from_string(const char* buffer, size_t msgsize, MMTF_container* thing )
+ * @brief Creates MMTF_container from string
+ * @param[in] buffer
+ * @param[in] msgsize
+ * @param[out] thing
+ * @return void
+ */
+void MMTF_unpack_from_string(const char* buffer, size_t msgsize, MMTF_container* thing);
+// clang-format on
 
-    /**
-     * @fn void MMTF_unpack_from_string(const char* buffer, size_t msgsize, MMTF_container* thing )
-     * @brief Creates MMTF_container from string
-     * @param[in] buffer
-     * @param[in] msgsize
-     * @param[out] thing
-     * @return void
-     */
-void MMTF_unpack_from_string(const char* buffer, size_t msgsize, MMTF_container* thing );
-
-
-    /**
-     * @fn void MMTF_unpack_from_file(const char* name, MMTF_container* thing)
-     * @brief Decode a MMTF_container from a file
-     * @param[in] name Filename of the mmtf file which you want to read
-     * @param[out] thing new/empty MMTF_container in  which the contents will be loaded by this function
-     * @return void
-     */
-void MMTF_unpack_from_file(const char* , MMTF_container* );
+/**
+ * @fn void MMTF_unpack_from_file(const char* name, MMTF_container* thing)
+ * @brief Decode a MMTF_container from a file
+ * @param[in] name Filename of the mmtf file which you want to read
+ * @param[out] thing new/empty MMTF_container in  which the contents will be loaded by this function
+ * @return void
+ */
+void MMTF_unpack_from_file(const char*, MMTF_container*);
 
 #undef WITHCOUNT
 
@@ -185,3 +186,5 @@ void MMTF_unpack_from_file(const char* , MMTF_container* );
 }
 #endif
 #endif
+
+// vi:sw=4:expandtab

--- a/src/mmtf_parser.h
+++ b/src/mmtf_parser.h
@@ -27,6 +27,7 @@
 #ifndef MMTF_PARSER_H
 #define MMTF_PARSER_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -181,16 +182,18 @@ CODEGEN_MMTF_parser_TYPE(MMTF_GroupType)
  * @param[in] buffer file contents
  * @param[in] size file size
  * @param[out] container initialized but empty MMTF container to populate with data
+ * @return true on success, false if an error occured
  */
-void MMTF_unpack_from_string(const char* buffer, size_t size, MMTF_container* container);
+bool MMTF_unpack_from_string(const char* buffer, size_t size, MMTF_container* container);
 // clang-format on
 
 /**
  * @brief Decode a MMTF_container from a file
  * @param[in] filename file path of an uncompressed .mmtf file
  * @param[out] container initialized but empty MMTF container to populate with data
+ * @return true on success, false if an error occured
  */
-void MMTF_unpack_from_file(const char* filename, MMTF_container* container);
+bool MMTF_unpack_from_file(const char* filename, MMTF_container* container);
 
 #undef WITHCOUNT
 

--- a/src/mmtf_parser.h
+++ b/src/mmtf_parser.h
@@ -34,6 +34,12 @@
 extern "C" {
 #endif
 
+/**
+ * @brief MMTF spec version which this library implements
+ */
+#define MMTF_SPEC_VERSION_MAJOR 1
+#define MMTF_SPEC_VERSION_MINOR 0
+
 #define WITHCOUNT(name) \
     name; \
     size_t name##Count

--- a/src/mmtf_parser.h
+++ b/src/mmtf_parser.h
@@ -1,33 +1,32 @@
-//*******************************************************************************
-//******	Copyright [2016] [RCSB]
-//******
-//******	Licensed under the Apache License, Version 2.0 (the "License");
-//******	you may not use this file except in compliance with the License.
-//******	You may obtain a copy of the License at
-//******
-//******	    http://www.apache.org/licenses/LICENSE-2.0
-//******
-//******	Unless required by applicable law or agreed to in writing, software
-//******	distributed under the License is distributed on an "AS IS" BASIS,
-//******	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//******	See the License for the specific language governing permissions and
-//******	limitations under the License.
-//******
-//******
-//******	This file is the header file for the MMTF parser for the C language.
-//******
-//******	The authors of this code are: Julien Ferté (http://www.julienferte.com/),
-//******	Anthony Bradley, Thomas Holder.
-//******
-//******
-//******	Other contributors: Yana Valasatava, Gazal Kalyan, Alexander Rose.
-//******
-//*******************************************************************************
+// *************************************************************************
+// Copyright [2016] [RCSB]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+// This file is the header file for the MMTF parser for the C language.
+//
+// The authors of this code are: Julien Ferte (http://www.julienferte.com/),
+// Anthony Bradley, Thomas Holder.
+//
+//
+// Other contributors: Yana Valasatava, Gazal Kalyan, Alexander Rose.
+//
+// *************************************************************************
 
 #ifndef MMTF_PARSER_H
 #define MMTF_PARSER_H
 
-//*** Standard libs
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -39,102 +38,102 @@ extern "C" {
     name; \
     size_t name##Count
 
-//*** The MMTF structure
-/** @brief Group (residue) level data store */
+/**
+ * @brief Group (residue) level data store
+ *
+ * https://github.com/rcsb/mmtf/blob/HEAD/spec.md#group-data
+ */
 typedef struct {
-    int32_t* formalChargeList;        /**< formalChargeList List of formal charges as Integers */
-    char** WITHCOUNT(atomNameList);   /**< List of atom names, 0 to 5 character Strings*/
-    char** WITHCOUNT(elementList);    /**< List of elements, 0 to 3 character Strings */
-    int32_t* WITHCOUNT(bondAtomList); /**< List of bonded atom indices, Integers */
-    int8_t* WITHCOUNT(bondOrderList); /**< List of bond orders as Integers between 1 and 4 */
-    char* groupName;                  /**< The name of the group, 0 to 5 characters */
-    char singleLetterCode;            /**< The single letter code, 1 character */
-    char* chemCompType;               /**< The chemical component type */
+    int32_t* formalChargeList;
+    char** WITHCOUNT(atomNameList);
+    char** WITHCOUNT(elementList);
+    int32_t* WITHCOUNT(bondAtomList);
+    int8_t* WITHCOUNT(bondOrderList);
+    char* groupName;
+    char singleLetterCode;
+    char* chemCompType;
 } MMTF_GroupType;
 
-/** @brief An Entity is defined as each of the distinct molecules present in a PDB structure. It can be of type polymer, non-polymer, macrolide or water */
+/**
+ * @brief Entity type.
+ *
+ * https://github.com/rcsb/mmtf/blob/HEAD/spec.md#entitylist
+ */
 typedef struct {
-    int32_t* WITHCOUNT(chainIndexList); /**< Indices of fields in chainIdList and chainNameList fields */
-    char* description;                  /**< Description of the entity */
-    char* type;                         /**< Name of the entity type */
-    char* sequence;                     /**< Sequence of the full construct in one-letter-code */
+    int32_t* WITHCOUNT(chainIndexList);
+    char* description;
+    char* type;
+    char* sequence;
 } MMTF_Entity;
 
-/** @brief The transformation needed for generation of biological assemblies from the contents of a PDB/mmCIF file. It contains both the actual transformation (rotation+translation) and the chain identifier to which it should be applied */
+/**
+ * @brief Transformation definition for a set of chains.
+ *
+ * https://github.com/rcsb/mmtf/blob/HEAD/spec.md#bioassemblylist
+ */
 typedef struct {
-    int32_t* WITHCOUNT(chainIndexList); /**< Indices of fields in chainIdList and chainNameList fields */
-    float matrix[16];                   /**< 4X4 Transformation matrix  */
+    int32_t* WITHCOUNT(chainIndexList);
+    float matrix[16];
 } MMTF_Transform;
 
-/** @brief Data store for the biological assembly annotation as provided by the PDB. Contains all the information required to build the Biological Assembly from the asymmetric unit */
+/**
+ * @brief Data store for the biological assembly annotation.
+ *
+ * https://github.com/rcsb/mmtf/blob/HEAD/spec.md#bioassemblylist
+ */
 typedef struct {
-    MMTF_Transform* WITHCOUNT(transformList); /**< List of MMTF_transform objects */
-    char* name;                               /**< Name of the biological assembly */
+    MMTF_Transform* WITHCOUNT(transformList);
+    char* name;
 } MMTF_BioAssembly;
 
-/** @brief MMTF container holds the MMTF data */
-
+/**
+ * @brief Top level MMTF data container.
+ *
+ * https://github.com/rcsb/mmtf/blob/HEAD/spec.md#fields
+ */
 typedef struct {
-    char* mmtfVersion;                            /**< The version of MMTF */
-    char* mmtfProducer;                           /**< The producer of MMTF */
-    float unitCell[6];                            /**< Array of 6 defining the unit cell: a, b, c, alpha, beta, gamma */
-    char* spaceGroup;                             /**< the space group name */
-    char* structureId;                            /**< An ID for the structure, for eg. the 4 letter PDB ID */
-    char* title;                                  /**< description of the structural data included in the file */
-    char* depositionDate;                         /**< Date of the deposition of the structure in a database in format YYY-MM-DD */
-    char* releaseDate;                            /**< Date of release of the structure in the database in format YYY-MM-DD */
-    MMTF_BioAssembly* WITHCOUNT(bioAssemblyList); /**< List of MMTF_BioAssembly objects */
-    MMTF_Entity* WITHCOUNT(entityList);           /**< List of MMTF_Entity objects */
+    char* mmtfVersion;
+    char* mmtfProducer;
+    float unitCell[6];
+    char* spaceGroup;
+    char* structureId;
+    char* title;
+    char* depositionDate;
+    char* releaseDate;
+    MMTF_BioAssembly* WITHCOUNT(bioAssemblyList);
+    MMTF_Entity* WITHCOUNT(entityList);
     char** WITHCOUNT(experimentalMethods);
-    /**< experimentalMethods is a character array of unknown length so we
-                             * need to specify the number of elements. String must be one of the
-                             * following: \n
-                             *  ELECTRON CRYSTALLOGRAPHY \n
-                             *  ELECTRON MICROSCOPY \n
-                             *  EPR \n
-                             *  FIBER DIFFRACTION \n
-                             *  FLUORESCENCE TRANSFER \n
-                             *  INFRARED SPECTROSCOPY \n
-                             *  NEUTRON DIFFRACTION \n
-                             *  POWDER DIFFRACTION \n
-                             *  SOLID-STATE NMR \n
-                             *  SOLUTION NMR \n
-                             *  SOLUTION SCATTERING \n
-                             *  THEORETICAL MODEL \n
-                             *  X-RAY DIFFRACTION
-                             */
-    size_t numberOfExperimentalMethods;   /**< The number of experimental methods for the structure */
-    float resolution;                     /**< Resolution of the structure */
-    float rFree;                          /**< Rfree of the structure. Used to assess possible overmodelling of the data */
-    float rWork;                          /**< Rwork of the structure. Used to assess the agreement between the crystallographic model and the experimental X-ray diffraction data */
-    int32_t numBonds;                     /**< Total number of bonds in the structure */
-    int32_t numAtoms;                     /**< Total number of atoms in the structure */
-    int32_t numGroups;                    /**< Total number of groups (residues) in the structure */
-    int32_t numChains;                    /**< Total number of chains in the structure */
-    int32_t numModels;                    /**< Total number of models in the structure */
-    MMTF_GroupType* WITHCOUNT(groupList); /**< List of MMTF_GroupType objects */
-    int32_t* WITHCOUNT(bondAtomList);     /**< Pairs of values represent indices of covalently bonded atoms */
-    int8_t* WITHCOUNT(bondOrderList);     /**< 8 bit signed integer */
-    float* xCoordList;                    /**< List of x coordinates */
-    float* yCoordList;                    /**< List of y coordinates */
-    float* zCoordList;                    /**< List of z coordinates */
-    float* bFactorList;                   /**< List of Bfactors */
-    int32_t* atomIdList;                  /**< List of atom serial numbers */
-    char* altLocList;                     /**< List of alternate locations */
-    float* occupancyList;                 /**< List of occupancies */
-    int32_t* groupIdList;                 /**< List of groups (residues) */
+    float resolution;
+    float rFree;
+    float rWork;
+    int32_t numBonds;
+    int32_t numAtoms;
+    int32_t numGroups;
+    int32_t numChains;
+    int32_t numModels;
+    MMTF_GroupType* WITHCOUNT(groupList);
+    int32_t* WITHCOUNT(bondAtomList);
+    int8_t* WITHCOUNT(bondOrderList);
+    float* xCoordList;
+    float* yCoordList;
+    float* zCoordList;
+    float* bFactorList;
+    int32_t* atomIdList;
+    char* altLocList;
+    float* occupancyList;
+    int32_t* groupIdList;
     int32_t* groupTypeList;
-    int8_t* secStructList; /**< List of of secondary structure assignments. See [specification](https://github.com/rcsb/mmtf/blob/v1.0/spec.md#secstructlist) */
-    char* insCodeList;     /**< List of insertion codes */
+    int8_t* secStructList;
+    char* insCodeList;
     int32_t* sequenceIndexList;
-    char** WITHCOUNT(chainIdList);   /**< Array of 4-char strings */
-    char** WITHCOUNT(chainNameList); /**< Array of 4-char strings */
-    int32_t* groupsPerChain;         /**< List of total number of groups in each chain */
-    int32_t* chainsPerModel;         /**< List of total number of chains in each model */
+    char** WITHCOUNT(chainIdList);
+    char** WITHCOUNT(chainNameList);
+    int32_t* groupsPerChain;
+    int32_t* chainsPerModel;
 } MMTF_container;
 
-/**
- * @brief Macros for declaration generic initialization and destroying functions
+/*
+ * Macros for declaration generic initialization and destroying functions
  */
 
 #define CODEGEN_MMTF_parser_TYPE(type) \
@@ -145,10 +144,23 @@ typedef struct {
     void type##_free(type*);
 
 /**
- * @fn MMTF_container_free(MMTF_container* thing)
- * @param thing The MMTF_container to be freed
- * @return void
+ * @fn MMTF_container * MMTF_container_new()
+ * @brief Allocate and initialize a new empty MMTF container
+ * @return pointer which needs to be freed with ::MMTF_container_free
+ *
+ * @fn void MMTF_container_free(MMTF_container* container)
+ * @brief Destroy the instance and free the memory
+ * @param container A MMTF container which has been allocated with ::MMTF_container_new
+ *
+ * @fn void MMTF_container_init(MMTF_container * container)
+ * @brief Initialize an empty MMTF container
+ * @param container Uninitialized memory, needs to be destroyed with ::MMTF_container_destroy
+ *
+ * @fn void MMTF_container_destroy(MMTF_container* container)
+ * @brief Destroy the instance and leave the memory uninitialized
+ * @param container A MMTF container which has been initialized with ::MMTF_container_init
  */
+
 // clang-format off
 CODEGEN_MMTF_parser_TYPE(MMTF_container)
 CODEGEN_MMTF_parser_TYPE(MMTF_BioAssembly)
@@ -158,27 +170,21 @@ CODEGEN_MMTF_parser_TYPE(MMTF_GroupType)
 
 #undef CODEGEN_MMTF_parser_TYPE
 
-/* MMTF and MsgPack */
-
 /**
- * @fn void MMTF_unpack_from_string(const char* buffer, size_t msgsize, MMTF_container* thing )
- * @brief Creates MMTF_container from string
- * @param[in] buffer
- * @param[in] msgsize
- * @param[out] thing
- * @return void
+ * @brief Decode a MMTF_container from a string
+ * @param[in] buffer file contents
+ * @param[in] size file size
+ * @param[out] container initialized but empty MMTF container to populate with data
  */
-void MMTF_unpack_from_string(const char* buffer, size_t msgsize, MMTF_container* thing);
+void MMTF_unpack_from_string(const char* buffer, size_t size, MMTF_container* container);
 // clang-format on
 
 /**
- * @fn void MMTF_unpack_from_file(const char* name, MMTF_container* thing)
  * @brief Decode a MMTF_container from a file
- * @param[in] name Filename of the mmtf file which you want to read
- * @param[out] thing new/empty MMTF_container in  which the contents will be loaded by this function
- * @return void
+ * @param[in] filename file path of an uncompressed .mmtf file
+ * @param[out] container initialized but empty MMTF container to populate with data
  */
-void MMTF_unpack_from_file(const char*, MMTF_container*);
+void MMTF_unpack_from_file(const char* filename, MMTF_container* container);
 
 #undef WITHCOUNT
 

--- a/src/mmtf_parser_private.h
+++ b/src/mmtf_parser_private.h
@@ -69,17 +69,12 @@ char* MMTF_parser_fetch_string(const msgpack_object*);
 int64_t MMTF_parser_fetch_int(const msgpack_object*);
 float MMTF_parser_fetch_float(const msgpack_object*);
 
-bool MMTF_parser_compare_msgpack_string_char_array(const msgpack_object_str*, const char*);
-
 MMTF_Entity* MMTF_parser_fetch_entityList(const msgpack_object*, size_t*);
 
 MMTF_GroupType* MMTF_parser_fetch_groupTypeList(const msgpack_object*, size_t*);
 
 MMTF_BioAssembly* MMTF_parser_fetch_bioAssemblyList(const msgpack_object*, size_t*);
 MMTF_Transform* MMTF_parser_fetch_transformList(const msgpack_object*, size_t*);
-
-//*** MMTF and MsgPack
-void MMTF_parser_msgpack_object_to_MMTF_container(const msgpack_object*, MMTF_container*);
 
 #ifdef __cplusplus
 }

--- a/src/mmtf_parser_private.h
+++ b/src/mmtf_parser_private.h
@@ -41,7 +41,7 @@
 #define MMTF_MSGPACK_TYPE(T) msgpack::type::T
 #else
 #include <msgpack.h>
-#define MMTF_MSGPACK_TYPE(T) MSGPACK_OBJECT_ ## T
+#define MMTF_MSGPACK_TYPE(T) MSGPACK_OBJECT_##T
 #endif
 
 #ifdef __cplusplus
@@ -49,38 +49,40 @@ extern "C" {
 #endif
 
 //*** Array converters
-float* MMTF_parser_float_from_bytes( const char*, uint32_t, uint32_t* );
-int8_t* MMTF_parser_int8_from_bytes( const char*, uint32_t, uint32_t* );
-int16_t* MMTF_parser_int16_from_bytes( const char*, uint32_t, uint32_t* );
-int32_t* MMTF_parser_int32_from_bytes( const char*, const uint32_t, uint32_t* );
-char** MMTF_parser_strings_from_bytes( const char*, uint32_t, uint32_t, uint32_t* );
+float* MMTF_parser_float_from_bytes(const char*, uint32_t, uint32_t*);
+int8_t* MMTF_parser_int8_from_bytes(const char*, uint32_t, uint32_t*);
+int16_t* MMTF_parser_int16_from_bytes(const char*, uint32_t, uint32_t*);
+int32_t* MMTF_parser_int32_from_bytes(const char*, const uint32_t, uint32_t*);
+char** MMTF_parser_strings_from_bytes(const char*, uint32_t, uint32_t, uint32_t*);
 
 //*** Array decoders
 int32_t* MMTF_parser_run_length_decode(const int32_t*, uint32_t, uint32_t*);
-int32_t* MMTF_parser_delta_decode(const int32_t*, uint32_t, uint32_t* );
+int32_t* MMTF_parser_delta_decode(const int32_t*, uint32_t, uint32_t*);
 int32_t* MMTF_parser_recursive_indexing_decode_from_16(const int16_t*, uint32_t, uint32_t*);
-int32_t* MMTF_parser_recursive_indexing_decode_from_8(const int8_t*, uint32_t, uint32_t* );
-float* MMTF_parser_integer_decode_from_16(const int16_t*, uint32_t, int32_t, uint32_t* );
-float* MMTF_parser_integer_decode_from_32(const int32_t*, uint32_t, int32_t, uint32_t* );
+int32_t* MMTF_parser_recursive_indexing_decode_from_8(const int8_t*, uint32_t, uint32_t*);
+float* MMTF_parser_integer_decode_from_16(const int16_t*, uint32_t, int32_t, uint32_t*);
+float* MMTF_parser_integer_decode_from_32(const int32_t*, uint32_t, int32_t, uint32_t*);
 
 //*** Unpacking from MsgPack and applying strategy
-char* MMTF_parser_fetch_string( const msgpack_object* );
-int64_t MMTF_parser_fetch_int( const msgpack_object* );
-float MMTF_parser_fetch_float( const msgpack_object* );
+char* MMTF_parser_fetch_string(const msgpack_object*);
+int64_t MMTF_parser_fetch_int(const msgpack_object*);
+float MMTF_parser_fetch_float(const msgpack_object*);
 
-bool MMTF_parser_compare_msgpack_string_char_array( const msgpack_object_str*, const char* );
+bool MMTF_parser_compare_msgpack_string_char_array(const msgpack_object_str*, const char*);
 
-MMTF_Entity* MMTF_parser_fetch_entityList( const msgpack_object*, size_t* );
+MMTF_Entity* MMTF_parser_fetch_entityList(const msgpack_object*, size_t*);
 
-MMTF_GroupType* MMTF_parser_fetch_groupTypeList( const msgpack_object*, size_t* );
+MMTF_GroupType* MMTF_parser_fetch_groupTypeList(const msgpack_object*, size_t*);
 
-MMTF_BioAssembly* MMTF_parser_fetch_bioAssemblyList( const msgpack_object*, size_t* );
-MMTF_Transform* MMTF_parser_fetch_transformList( const msgpack_object*, size_t* );
+MMTF_BioAssembly* MMTF_parser_fetch_bioAssemblyList(const msgpack_object*, size_t*);
+MMTF_Transform* MMTF_parser_fetch_transformList(const msgpack_object*, size_t*);
 
 //*** MMTF and MsgPack
-void MMTF_parser_msgpack_object_to_MMTF_container( const msgpack_object*, MMTF_container* );
+void MMTF_parser_msgpack_object_to_MMTF_container(const msgpack_object*, MMTF_container*);
 
 #ifdef __cplusplus
 }
 #endif
 #endif
+
+// vi:sw=4:expandtab

--- a/src/mmtf_parser_private.h
+++ b/src/mmtf_parser_private.h
@@ -1,28 +1,29 @@
-//*******************************************************************************
-//******	Copyright [2016] [RCSB]
-//******
-//******	Licensed under the Apache License, Version 2.0 (the "License");
-//******	you may not use this file except in compliance with the License.
-//******	You may obtain a copy of the License at
-//******
-//******	    http://www.apache.org/licenses/LICENSE-2.0
-//******
-//******	Unless required by applicable law or agreed to in writing, software
-//******	distributed under the License is distributed on an "AS IS" BASIS,
-//******	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//******	See the License for the specific language governing permissions and
-//******	limitations under the License.
-//******
-//******
-//******	This file is the header file for the MMTF parser for the C language.
-//******
-//******	The authors of this code are: Julien Ferté (http://www.julienferte.com/),
-//******	Anthony Bradley, Thomas Holder.
-//******
-//******
-//******	Other contributors: Yana Valasatava, Alexander Rose.
-//******
-//*******************************************************************************
+// *************************************************************************
+// Copyright [2016] [RCSB]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+// This is a private header file for mmtf_parser.c and must not be included
+// by other files.
+//
+// The authors of this code are: Julien Ferte (http://www.julienferte.com/),
+// Anthony Bradley, Thomas Holder.
+//
+//
+// Other contributors: Yana Valasatava, Alexander Rose.
+//
+// *************************************************************************
 
 #ifndef MMTF_PRIVATE_H
 #define MMTF_PRIVATE_H


### PR DESCRIPTION
This pull request addresses issues #23 and #24.

Code formatting with clang-format. The file **codeformat.sh** runs clang-format and some additional auto-formatting which is not configurable in clang-format.

Remove doc which duplicates MMTF spec. Document all "public" functions and add links to MMTF spec.

Add semantic versioning check, the parser will not load files with an unsupported major version.